### PR TITLE
Improved integration with GitHub and other types of projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[{.jshintrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/assets/css/gp-auto-extract.css
+++ b/assets/css/gp-auto-extract.css
@@ -1,51 +1,51 @@
 .source-type-none .hide-if-none {
-    display: none !important;
+	display: none !important;
 }
 .source-type-none .show-if-github {
-    display: none !important;
+	display: none !important;
 }
 .source-type-none .show-if-wordpress {
-    display: none !important;
+	display: none !important;
 }
 .source-type-none .show-if-custom {
-    display: none !important;
+	display: none !important;
 }
 
 .source-type-github .hide-if-github {
-    display: none !important;
+	display: none !important;
 }
 .source-type-github .show-if-none {
-    display: none !important;
+	display: none !important;
 }
 .source-type-github .show-if-wordpress {
-    display: none !important;
+	display: none !important;
 }
 .source-type-github .show-if-custom {
-    display: none !important;
+	display: none !important;
 }
 
 .source-type-wordpress .hide-if-wordpress {
-    display: none !important;
+	display: none !important;
 }
 .source-type-wordpress .show-if-none {
-    display: none !important;
+	display: none !important;
 }
 .source-type-wordpress .show-if-github {
-    display: none !important;
+	display: none !important;
 }
 .source-type-wordpress .show-if-custom {
-    display: none !important;
+	display: none !important;
 }
 
 .source-type-custom .hide-if-custom {
-    display: none !important;
+	display: none !important;
 }
 .source-type-custom .show-if-none {
-    display: none !important;
+	display: none !important;
 }
 .source-type-custom .show-if-github {
-    display: none !important;
+	display: none !important;
 }
 .source-type-custom .show-if-wordpress {
-    display: none !important;
+	display: none !important;
 }

--- a/assets/css/gp-auto-extract.css
+++ b/assets/css/gp-auto-extract.css
@@ -1,0 +1,51 @@
+.source-type-none .hide-if-none {
+    display: none !important;
+}
+.source-type-none .show-if-github {
+    display: none !important;
+}
+.source-type-none .show-if-wordpress {
+    display: none !important;
+}
+.source-type-none .show-if-custom {
+    display: none !important;
+}
+
+.source-type-github .hide-if-github {
+    display: none !important;
+}
+.source-type-github .show-if-none {
+    display: none !important;
+}
+.source-type-github .show-if-wordpress {
+    display: none !important;
+}
+.source-type-github .show-if-custom {
+    display: none !important;
+}
+
+.source-type-wordpress .hide-if-wordpress {
+    display: none !important;
+}
+.source-type-wordpress .show-if-none {
+    display: none !important;
+}
+.source-type-wordpress .show-if-github {
+    display: none !important;
+}
+.source-type-wordpress .show-if-custom {
+    display: none !important;
+}
+
+.source-type-custom .hide-if-custom {
+    display: none !important;
+}
+.source-type-custom .show-if-none {
+    display: none !important;
+}
+.source-type-custom .show-if-github {
+    display: none !important;
+}
+.source-type-custom .show-if-wordpress {
+    display: none !important;
+}

--- a/assets/js/gp-auto-extract.js
+++ b/assets/js/gp-auto-extract.js
@@ -1,59 +1,59 @@
 jQuery( document ).ready( function() {
-    var toggle_group = function( value ) {
-        var group = jQuery( value ).data( 'group' );
-        if ( jQuery( value ).is( ':checked' ) ) {
-            jQuery( '.group-' + group ).removeClass( 'hidden' );
-        } else {
-            jQuery( '.group-' + group ).addClass( 'hidden' );
-        }
-    };
+	var toggle_group = function( value ) {
+		var group = jQuery( value ).data( 'group' );
+		if ( jQuery( value ).is( ':checked' ) ) {
+			jQuery( '.group-' + group ).removeClass( 'hidden' );
+		} else {
+			jQuery( '.group-' + group ).addClass( 'hidden' );
+		}
+	};
 
-    jQuery( '.editinline' ).click( function() {
-        var project_id = jQuery( this ).data( 'project-id' );
-        jQuery( '#project-' + project_id ).addClass( 'hidden' );
-        jQuery( '#edit-project-' + project_id ).removeClass( 'hidden' );
-        jQuery( '.group-toggle' ).each( function( index, value ) {
-            toggle_group( value );
-            jQuery( '.source_type' ).change();
-        } );
-    } );
+	jQuery( '.editinline' ).click( function() {
+		var project_id = jQuery( this ).data( 'project-id' );
+		jQuery( '#project-' + project_id ).addClass( 'hidden' );
+		jQuery( '#edit-project-' + project_id ).removeClass( 'hidden' );
+		jQuery( '.group-toggle' ).each( function( index, value ) {
+			toggle_group( value );
+			jQuery( '.source_type' ).change();
+		} );
+	} );
 
-    jQuery( '.inline-edit-save .cancel' ).click( function() {
-        var project_id = jQuery( this ).data( 'project-id' );
-        jQuery( '#project-' + project_id ).removeClass( 'hidden' );
-        jQuery( '#edit-project-' + project_id ).addClass( 'hidden' );
-    } );
+	jQuery( '.inline-edit-save .cancel' ).click( function() {
+		var project_id = jQuery( this ).data( 'project-id' );
+		jQuery( '#project-' + project_id ).removeClass( 'hidden' );
+		jQuery( '#edit-project-' + project_id ).addClass( 'hidden' );
+	} );
 
-    jQuery( '.group-toggle' ).click( function() {
-        toggle_group( this );
-    } );
+	jQuery( '.group-toggle' ).click( function() {
+		toggle_group( this );
+	} );
 
-    jQuery( '.source_type' ).change( function() {
-        var $tr = jQuery( this ).closest( 'tr' );
-        $tr.removeClass( 'source-type-none' );
-        $tr.removeClass( 'source-type-github' );
-        $tr.removeClass( 'source-type-wordpress' );
-        $tr.removeClass( 'source-type-custom' );
+	jQuery( '.source_type' ).change( function() {
+		var $tr = jQuery( this ).closest( 'tr' );
+		$tr.removeClass( 'source-type-none' );
+		$tr.removeClass( 'source-type-github' );
+		$tr.removeClass( 'source-type-wordpress' );
+		$tr.removeClass( 'source-type-custom' );
 
-        var source_type = jQuery( this ).val();
-        $tr.addClass( 'source-type-' + source_type );
+		var source_type = jQuery( this ).val();
+		$tr.addClass( 'source-type-' + source_type );
 
-        var $setting = jQuery( '.gpae-setting', $tr );
-        var $password = jQuery( '.gpae-password', $tr );
-        $setting.attr( 'placeholder', gpae.settings[source_type] );
-        $password.attr( 'placeholder', gpae.passwords[source_type] );
-    } );
+		var $setting = jQuery( '.gpae-setting', $tr );
+		var $password = jQuery( '.gpae-password', $tr );
+		$setting.attr( 'placeholder', gpae.settings[source_type] );
+		$password.attr( 'placeholder', gpae.passwords[source_type] );
+	} );
 
-    jQuery( '.extract-project, .reset-project' ).click( function() {
-        var $form = jQuery( 'form#gp-auto-extract' );
+	jQuery( '.extract-project, .reset-project' ).click( function() {
+		var $form = jQuery( 'form#gp-auto-extract' );
 
-        var $field = jQuery( '<input></input>' );
-        $field.attr( 'type', 'hidden' );
-        $field.attr( 'name', this.id );
-        $field.attr( 'value', 1 );
+		var $field = jQuery( '<input></input>' );
+		$field.attr( 'type', 'hidden' );
+		$field.attr( 'name', this.id );
+		$field.attr( 'value', 1 );
 
-        $form.append( $field );
+		$form.append( $field );
 
-        $form.submit();
-    } );
+		$form.submit();
+	} );
 } );

--- a/assets/js/gp-auto-extract.js
+++ b/assets/js/gp-auto-extract.js
@@ -62,4 +62,23 @@ jQuery( document ).ready( function() {
 	jQuery( document ).on( 'click', '#TB_window .close', function() {
 		tb_remove();
 	} );
+
+	jQuery( '.gpae-password' ).each( function( index, value ) {
+		var $this = jQuery( this );
+		$this.val( $this.data( 'masked-value' ) );
+	} );
+
+	jQuery( '.gpae-password' ).focus( function() {
+		var $this = jQuery( this );
+		if ( $this.val() === $this.data( 'masked-value' ) ) {
+			$this.val( '' );
+		}
+	} );
+
+	jQuery( '.gpae-password' ).blur(function() {
+		var $this = jQuery( this );
+		if ( $this.val() === '' ) {
+			$this.val( $this.data( 'masked-value' ) );
+		}
+	} );
 } );

--- a/assets/js/gp-auto-extract.js
+++ b/assets/js/gp-auto-extract.js
@@ -16,6 +16,7 @@ jQuery( document ).ready( function() {
 			toggle_group( value );
 			jQuery( '.source_type' ).change();
 		} );
+		return false;
 	} );
 
 	jQuery( '.inline-edit-save .cancel' ).click( function() {
@@ -55,10 +56,6 @@ jQuery( document ).ready( function() {
 		$form.append( $field );
 
 		$form.submit();
-		return false;
-	} );
-
-	jQuery( '.editinline' ).click( function() {
 		return false;
 	} );
 

--- a/assets/js/gp-auto-extract.js
+++ b/assets/js/gp-auto-extract.js
@@ -61,4 +61,8 @@ jQuery( document ).ready( function() {
 	jQuery( '.editinline' ).click( function() {
 		return false;
 	} );
+
+	jQuery( document ).on( 'click', '#TB_window .close', function() {
+		tb_remove();
+	} );
 } );

--- a/assets/js/gp-auto-extract.js
+++ b/assets/js/gp-auto-extract.js
@@ -1,0 +1,59 @@
+jQuery( document ).ready( function() {
+    var toggle_group = function( value ) {
+        var group = jQuery( value ).data( 'group' );
+        if ( jQuery( value ).is( ':checked' ) ) {
+            jQuery( '.group-' + group ).removeClass( 'hidden' );
+        } else {
+            jQuery( '.group-' + group ).addClass( 'hidden' );
+        }
+    };
+
+    jQuery( '.editinline' ).click( function() {
+        var project_id = jQuery( this ).data( 'project-id' );
+        jQuery( '#project-' + project_id ).addClass( 'hidden' );
+        jQuery( '#edit-project-' + project_id ).removeClass( 'hidden' );
+        jQuery( '.group-toggle' ).each( function( index, value ) {
+            toggle_group( value );
+            jQuery( '.source_type' ).change();
+        } );
+    } );
+
+    jQuery( '.inline-edit-save .cancel' ).click( function() {
+        var project_id = jQuery( this ).data( 'project-id' );
+        jQuery( '#project-' + project_id ).removeClass( 'hidden' );
+        jQuery( '#edit-project-' + project_id ).addClass( 'hidden' );
+    } );
+
+    jQuery( '.group-toggle' ).click( function() {
+        toggle_group( this );
+    } );
+
+    jQuery( '.source_type' ).change( function() {
+        var $tr = jQuery( this ).closest( 'tr' );
+        $tr.removeClass( 'source-type-none' );
+        $tr.removeClass( 'source-type-github' );
+        $tr.removeClass( 'source-type-wordpress' );
+        $tr.removeClass( 'source-type-custom' );
+
+        var source_type = jQuery( this ).val();
+        $tr.addClass( 'source-type-' + source_type );
+
+        var $setting = jQuery( '.gpae-setting', $tr );
+        var $password = jQuery( '.gpae-password', $tr );
+        $setting.attr( 'placeholder', gpae.settings[source_type] );
+        $password.attr( 'placeholder', gpae.passwords[source_type] );
+    } );
+
+    jQuery( '.extract-project, .reset-project' ).click( function() {
+        var $form = jQuery( 'form#gp-auto-extract' );
+
+        var $field = jQuery( '<input></input>' );
+        $field.attr( 'type', 'hidden' );
+        $field.attr( 'name', this.id );
+        $field.attr( 'value', 1 );
+
+        $form.append( $field );
+
+        $form.submit();
+    } );
+} );

--- a/assets/js/gp-auto-extract.js
+++ b/assets/js/gp-auto-extract.js
@@ -55,5 +55,10 @@ jQuery( document ).ready( function() {
 		$form.append( $field );
 
 		$form.submit();
+		return false;
+	} );
+
+	jQuery( '.editinline' ).click( function() {
+		return false;
 	} );
 } );

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -224,10 +224,6 @@ class GP_Auto_Extract extends GP_Route_Main {
 					$src_dir .= '/' . $src_files[2];
 				}
 			}
-			// Fudge the project name and version so the makepot call doesn't generate warnings about them.
-			$makepot->meta['generic']['package-name'] = $project->name;
-			$makepot->meta['generic']['package-version'] = 'trunk';
-
 
 			$skip_makepot  = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
 			$import_format = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
@@ -242,6 +238,10 @@ class GP_Auto_Extract extends GP_Route_Main {
 			} else {
 
 				$makepot = new MakePOT;
+
+				// Fudge the project name and version so the makepot call doesn't generate warnings about them.
+				$makepot->meta['generic']['package-name'] = $project->name;
+				$makepot->meta['generic']['package-version'] = 'trunk';
 
 				$makepot->generic( $src_dir, $temp_pot );
 

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -62,9 +62,9 @@ class GP_Auto_Extract extends GP_Route_Main {
 		$this->source_types = array( 'none' => __( 'none' ), 'github' => __( 'GitHub' ), 'wordpress' => __( 'WordPress.org' ), 'custom' => __( 'Custom' ) );
 		$this->source_type_templates = array(
 			'none'      => '',
-			'github'    => 'https://github.com/%s/archive/%s.zip',
-			'wordpress' => 'https://downloads.wordpress.org/plugin/%s.zip',
-			'custom'    => '%s',
+			'github'    => 'https://github.com/%1$s/archive/%2$s.zip',
+			'wordpress' => 'https://downloads.wordpress.org/plugin/%1$s.zip',
+			'custom'    => '%1$s',
 		);
 		$this->url_credentials = array();
 
@@ -278,7 +278,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			} else {
 				unlink( $source_file );
 
-				return '<div class="notice updated"><p>' . sprintf( __( 'Failed to extract zip file: "%s".' ), $source_file ) . '</p></div>';
+				return '<div class="notice error"><p>' . sprintf( __( 'Failed to extract zip file: "%s".' ), $source_file ) . '</p></div>';
 			}
 
 			$src_dir = $temp_dir;
@@ -341,7 +341,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			unlink( $temp_pot );
 
 			if ( false === $translations ) {
-				return '<div class="notice updated"><p>' . __( 'Failed to read strings from source code.' ) . '</p></div>';
+				return '<div class="notice error"><p>' . __( 'Failed to read strings from source code.' ) . '</p></div>';
 			}
 
 			list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted ) = GP::$original->import_for_project( $project, $translations );

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -112,6 +112,8 @@ class GP_Auto_Extract extends GP_Route_Main {
 		);
 		wp_localize_script( 'gp-auto-extract-js', 'gpae', $translation_array );
 		wp_enqueue_script( 'gp-auto-extract-js' );
+
+		add_thickbox();
 	}
 
 	/**
@@ -495,10 +497,12 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 		if ( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings ) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' !== $project_settings[ $project->id ]['type'] ) {
 			$row_actions .= sprintf(
-				' | <span class="trash"><a href="" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
+				//' | <span class="trash"><a href="" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
+				' | <span class="trash"><a href="#TB_inline;height=130;width=380;inlineId=confirm-reset-%1$s" class="submitdelete thickbox" aria-label="%2$s" title="%3$s">%4$s</a></span>',
 				esc_attr( $project->id ),
 				/* translators: %s: project name */
 				esc_attr( sprintf( __( 'Reset &#8220;%s&#8221;' ), $project->name ) ),
+				__( 'Are you sure?' ),
 				__( 'Reset' )
 			);
 
@@ -533,6 +537,13 @@ class GP_Auto_Extract extends GP_Route_Main {
 							<?php
 							echo $row_actions;
 							?>
+							<div id="confirm-reset-<?php echo esc_attr( $project->id ); ?>" style="display:none;">
+								<p><?php printf( __( 'You will lose all project "%s" settings.' ), $project->name ); ?></p>
+								<p>
+									<button type="submit" class="button button-primary reset-project" id="delete_<?php echo esc_attr( $project->id ); ?>"><?php _e( 'Reset' ); ?></button>
+									<button type="button" class="button close" data-project-id="<?php echo esc_attr( $project->id ); ?>"><?php _e( 'Cancel' ); ?></button>
+								</p>
+							</div>
 						</div>
 					</td>
 					<td><?php echo $this->source_types[ $source_type ]; ?></td>

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -299,9 +299,25 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 			if ( 'on' === $skip_makepot ) {
 
-				$format = gp_array_get( GP::$formats, $import_format, null );
+				$file_path = $src_dir . ( '/' === $import_file[0] ? '' : '/' ) . $import_file;
 
-				$pot_file = $format->read_originals_from_file( $src_dir . ( '/' === $import_file[0] ? '' : '/' ) . $import_file );
+				$format = gp_get_import_file_format( $import_format ?: 'auto', $file_path );
+
+				if ( ! $format ) {
+					if ( true === $format_message ) {
+						$message .= '<div class="notice error"><p>';
+					}
+
+					$message .= sprintf( __( 'Failed to detect format for "%s".' ), $import_file ) . '</p></div>';
+
+					if ( true === $format_message ) {
+						$message .= '</p></div>';
+					}
+
+					return $message;
+				}
+
+				$pot_file = $file_path;
 
 			} else {
 
@@ -348,7 +364,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			}
 		} else {
 			if ( true === $format_message ) {
-				$message .= '<div class="notice updated"><p>';
+				$message .= '<div class="notice error"><p>';
 			}
 
 			$message .= sprintf( __( 'Failed to download "%s".' ), $url_name ) . '</p></div>';
@@ -583,10 +599,11 @@ class GP_Auto_Extract extends GP_Route_Main {
 										<span class="title"><?php _e( 'Format' ); ?></span>
 										<?php
 										$format_options = array();
+										$format_options['auto'] = __( 'Auto Detect' );
 										foreach ( GP::$formats as $slug => $format ) {
 											$format_options[ $slug ] = $format->name;
 										}
-										echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'po' );
+										echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'auto' );
 										?>
 									</label>
 								</div>

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -119,7 +119,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 	// Without this placeholder there is a fatal error generated.
 	public function after_request() {
 	}
-	
+
 	// This function adds the "Auto Extract" option to the projects menu.
 	public function gp_project_actions( $actions, $project ) {
 		$project_settings = (array)get_option( 'gp_auto_extract', array() );
@@ -172,9 +172,11 @@ class GP_Auto_Extract extends GP_Route_Main {
             $project_settings[ $project->id ]['branch'] ?: 'master'
         );
 
-        $use_http_basic_auth = $project_settings[ $project->id ]['use_http_basic_auth'];
-        $http_auth_username  = $project_settings[ $project->id ]['http_auth_username'];
-        $http_auth_password  = $project_settings[ $project->id ]['http_auth_password'];
+        $current_project = $project_settings[ $project->id ];
+
+        $use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
+        $http_auth_username  = array_key_exists( 'http_auth_usernamehttp_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
+        $http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
 
         if ( 'on' === $use_http_basic_auth ) {
             $this->url_credentials[ $url_name ] = $http_auth_username . ':' . $http_auth_password;
@@ -225,11 +227,11 @@ class GP_Auto_Extract extends GP_Route_Main {
 			// Fudge the project name and version so the makepot call doesn't generate warnings about them.
 			$makepot->meta['generic']['package-name'] = $project->name;
 			$makepot->meta['generic']['package-version'] = 'trunk';
-			
 
-            $skip_makepot  = $project_settings[ $project->id ]['skip_makepot'];
-            $import_format = $project_settings[ $project->id ]['import_format'];
-            $import_file   = $project_settings[ $project->id ]['import_file'];
+
+            $skip_makepot  = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
+            $import_format = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
+            $import_file   = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
 
             if ( 'on' === $skip_makepot ) {
 
@@ -373,15 +375,17 @@ class GP_Auto_Extract extends GP_Route_Main {
 		$setting = '';
 
 		if( array_key_exists( $project->id, $project_settings ) ) {
-			$source_type         = $project_settings[ $project->id ]['type'];
-			$setting             = $project_settings[ $project->id ]['setting'];
-            $branch              = $project_settings[ $project->id ]['branch'];
-            $use_http_basic_auth = $project_settings[ $project->id ]['use_http_basic_auth'] ?: false;
-            $http_auth_username  = $project_settings[ $project->id ]['http_auth_username'];
-            $http_auth_password  = $project_settings[ $project->id ]['http_auth_password'];
-            $skip_makepot        = $project_settings[ $project->id ]['skip_makepot'] ?: false;
-            $import_format       = $project_settings[ $project->id ]['import_format'];
-            $import_file         = $project_settings[ $project->id ]['import_file'];
+            $current_project = $project_settings[ $project->id ];
+
+			$source_type         = array_key_exists( 'type', $current_project ) ? $current_project['type'] : 'none';
+			$setting             = array_key_exists( 'setting', $current_project ) ? $current_project['setting'] : '';
+            $branch              = array_key_exists( 'branch', $current_project ) ? $current_project['branch'] : '';
+            $use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
+            $http_auth_username  = array_key_exists( 'http_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
+            $http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
+            $skip_makepot        = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
+            $import_format       = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
+            $import_file         = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
 		}
 
 		$row_actions = '';

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -1,17 +1,19 @@
 <?php
-/*
-Plugin Name: GP Auto Extract
-Plugin URI: http://glot-o-matic.com/gp-auto-extract
-Description: Automatically extract source strings from a remote repo.
-Version: 0.7
-Author: Greg Ross
-Author URI: http://toolstack.com
-Tags: glotpress, glotpress plugin, translate
-License: GPLv2
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-*/
+/**
+ * Plugin Name: GP Auto Extract
+ * Plugin URI: http://glot-o-matic.com/gp-auto-extract
+ * Description: Automatically extract source strings from a remote repo.
+ * Version: 0.7
+ * Author: Greg Ross
+ * Author URI: http://toolstack.com
+ * Tags: glotpress, glotpress plugin, translate
+ * License: GPLv2
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package GlotPress
+ */
 
-/*
+/**
  * Ok, we're going to cheat a little bit here and create our main class as an extension of the GP_Route_Main class.
  *
  * This let's us use it for both the main class of our plugin AND the class to handle the route for the front end
@@ -21,12 +23,41 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * stub functions to mimic the GP_Route class that the GP Router needs to function correctly.
  */
 class GP_Auto_Extract extends GP_Route_Main {
+	/**
+	 * Id of instance.
+	 *
+	 * @access public
+	 * @var String $id
+	 */
 	public $id = 'gp-auto-extract';
 
+	/**
+	 * All supported source types.
+	 *
+	 * @access private
+	 * @var Array $source_types
+	 */
 	private $source_types;
-	private $source_type_templates;
-	private $url_credentials = array();
 
+	/**
+	 * Url templates for source types.
+	 *
+	 * @access private
+	 * @var Array $source_type_templates
+	 */
+	private $source_type_templates;
+
+	/**
+	 * Cache of username and password for HTTP Basic Authentication filter.
+	 *
+	 * @access private
+	 * @var Array $url_credentials
+	 */
+	private $url_credentials;
+
+	/**
+	 * Initialize the variables, hooks and setup GlotPress API routes.
+	 */
 	public function __construct() {
 		$this->source_types = array( 'none' => __( 'none' ), 'github' => __( 'GitHub' ), 'wordpress' => __( 'WordPress.org' ), 'custom' => __( 'Custom' ) );
 		$this->source_type_templates = array(
@@ -35,54 +66,66 @@ class GP_Auto_Extract extends GP_Route_Main {
 			'wordpress' => 'https://downloads.wordpress.org/plugin/%s.zip',
 			'custom'    => '%s',
 		);
+		$this->url_credentials = array();
 
 		// Add the admin page to the WordPress settings menu.
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 10, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_custom_wp_admin_style' ) );
 
 		// If the user has write permissions to the projects, add the auto extract option to the projects menu.
-		if( GP::$permission->user_can( wp_get_current_user(), 'write', 'project' ) ) {
+		if ( GP::$permission->user_can( wp_get_current_user(), 'write', 'project' ) ) {
 			add_action( 'gp_project_actions', array( $this, 'gp_project_actions' ), 10, 2 );
 		}
 
 		// We can't use the filter in the defaults route code because plugins don't load until after
 		// it has already run, so instead add the routes directly to the global GP_Router object.
-		GP::$router->add( "/auto-extract/(.+?)", array( $this, 'auto_extract' ), 'get' );
-		GP::$router->add( "/auto-extract/(.+?)", array( $this, 'auto_extract' ), 'post' );
+		GP::$router->add( '/auto-extract/(.+?)', array( $this, 'auto_extract' ), 'get' );
+		GP::$router->add( '/auto-extract/(.+?)', array( $this, 'auto_extract' ), 'post' );
 	}
 
+	/**
+	 * Enqueues the admin assets.
+	 *
+	 * @param String $hook Admin page hook name.
+	 */
 	public function load_custom_wp_admin_style( $hook ) {
-			// Load only on ?page=gp-auto-extract.php
-			if ( $hook != 'settings_page_gp-auto-extract' ) {
-				return;
-			}
-			wp_enqueue_style( 'gp-auto-extract-css', plugins_url('assets/css/gp-auto-extract.css', __FILE__) );
+		// Load only on ?page=gp-auto-extract.php.
+		if ( 'settings_page_gp-auto-extract' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style( 'gp-auto-extract-css', plugins_url( 'assets/css/gp-auto-extract.css', __FILE__ ) );
 
-			wp_register_script( 'gp-auto-extract-js', plugins_url('assets/js/gp-auto-extract.js', __FILE__) );
-			$translation_array = array(
-				'passwords' => array(
-					'none' => '',
-					'github' => __( 'or Personal Access Token' ),
-					'wordpress' => '',
-					'custom' => '',
-				),
-				'settings' => array(
-					'none' => '',
-					'github' => __( 'username/repository' ),
-					'wordpress' => __( 'plugin-or-theme-slug' ),
-					'custom' => __( 'url for a valid archive with source files' ),
-				),
-			);
-			wp_localize_script( 'gp-auto-extract-js', 'gpae', $translation_array );
-			wp_enqueue_script( 'gp-auto-extract-js' );
+		wp_register_script( 'gp-auto-extract-js', plugins_url( 'assets/js/gp-auto-extract.js', __FILE__ ) );
+		$translation_array = array(
+			'passwords' => array(
+				'none' => '',
+				'github' => esc_attr__( 'or Personal Access Token' ),
+				'wordpress' => '',
+				'custom' => '',
+			),
+			'settings' => array(
+				'none' => '',
+				'github' => esc_attr__( 'username/repository' ),
+				'wordpress' => esc_attr__( 'plugin-or-theme-slug' ),
+				'custom' => esc_attr__( 'url for a valid archive with source files' ),
+			),
+		);
+		wp_localize_script( 'gp-auto-extract-js', 'gpae', $translation_array );
+		wp_enqueue_script( 'gp-auto-extract-js' );
 	}
 
-	// This function is here as placeholder to support adding the auto extract option to the router.
-	// Without this placeholder there is a fatal error generated.
+	/**
+	 * This function is here as placeholder to support adding the auto extract option to the router.
+	 * Without this placeholder there is a fatal error generated.
+	 */
 	public function before_request() {
 	}
 
-	// This function handles the actual auto extract passed in by the router for the projects menu.
+	/**
+	 * This function handles the actual auto extract passed in by the router for the projects menu.
+	 *
+	 * @param String $project_path The url path to the project.
+	 */
 	public function auto_extract( $project_path ) {
 		// First let's ensure we have decoded the project path for use later.
 		$project_path = urldecode( $project_path );
@@ -96,9 +139,9 @@ class GP_Auto_Extract extends GP_Route_Main {
 		// Get the project object from the project path that was passed in.
 		$project_obj = $project_class->by_path( $project_path );
 
-		if( GP::$permission->user_can( wp_get_current_user(), 'write', 'project', $project_obj->id ) ) {
+		if ( GP::$permission->user_can( wp_get_current_user(), 'write', 'project', $project_obj->id ) ) {
 			// Get the project settings.
-			$project_settings = (array)get_option( 'gp_auto_extract', array() );
+			$project_settings = (array) get_option( 'gp_auto_extract', array() );
 
 			// Since we're running on the front end we need to load the download_url() function from the wp-admin/includes directory.
 			include( ABSPATH . 'wp-admin/includes/file.php' );
@@ -115,46 +158,73 @@ class GP_Auto_Extract extends GP_Route_Main {
 		wp_redirect( $url );
 	}
 
-	// This function is here as placeholder to support adding the auto extract option to the router.
-	// Without this placeholder there is a fatal error generated.
+	/**
+	 * This function is here as placeholder to support adding the auto extract option to the router.
+	 * Without this placeholder there is a fatal error generated.
+	 */
 	public function after_request() {
 	}
 
-	// This function adds the "Auto Extract" option to the projects menu.
+	/**
+	 * This function adds the "Auto Extract" option to the projects menu.
+	 *
+	 * @param Array      $actions Array containing project actions.
+	 * @param GP_Project $project The GlotPress Project.
+	 * @return Array Processed actions.
+	 */
 	public function gp_project_actions( $actions, $project ) {
-		$project_settings = (array)get_option( 'gp_auto_extract', array() );
+		$project_settings = (array) get_option( 'gp_auto_extract', array() );
 
-		if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
-			$actions[] .= gp_link_get( gp_url( 'auto-extract/' . $project->slug), __('Auto Extract') );
+		if ( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings ) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' !== $project_settings[ $project->id ]['type'] ) {
+			$actions[] .= gp_link_get( gp_url( 'auto-extract/' . $project->slug ), esc_html__( 'Auto Extract' ) );
 		}
 
 		return $actions;
 	}
 
+	/**
+	 * Removes a folder and all its content recursively.
+	 *
+	 * @access private
+	 *
+	 * @param String $dir Folder to remove.
+	 * @return Bool True if folder was removed, false if not.
+	 */
 	private function delTree( $dir ) {
-		if( ! gp_startswith( $dir, sys_get_temp_dir() ) ) {
+		if ( ! gp_startswith( $dir, sys_get_temp_dir() ) ) {
 			return false;
 		}
 
 		$files = array_diff( scandir( $dir ), array( '.', '..' ) );
 
 		foreach ( $files as $file ) {
-			if( is_dir( "$dir/$file" ) ) {
-				$this->delTree("$dir/$file");
+			if ( is_dir( "$dir/$file" ) ) {
+				$this->delTree( "$dir/$file" );
 			} else {
-				unlink("$dir/$file");
+				unlink( "$dir/$file" );
 			}
 		}
 
 		return rmdir( $dir );
 	}
 
-	// This function adds the admin settings page to WordPress.
+	/**
+	 * This function adds the admin settings page to WordPress.
+	 */
 	public function admin_menu() {
-		add_options_page( __('GP Auto Extract'), __('GP Auto Extract'), 'manage_options', basename( __FILE__ ), array( $this, 'admin_page' ) );
+		add_options_page( esc_html__( 'GP Auto Extract' ), esc_html__( 'GP Auto Extract' ), 'manage_options', basename( __FILE__ ), array( $this, 'admin_page' ) );
 	}
 
-	public function authenticate_download( $r, $url) {
+	/**
+	 * Downloads the source files and import the translations.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param Array $r   Original Request.
+	 * @param Array $url Url being requested.
+	 * @return Array Processed request.
+	 */
+	public function authenticate_download( $r, $url ) {
 		if ( array_key_exists( $url, $this->url_credentials ) ) {
 			if ( ! is_array( $r['headers'] ) ) {
 				$r['headers'] = array();
@@ -165,6 +235,16 @@ class GP_Auto_Extract extends GP_Route_Main {
 		return $r;
 	}
 
+	/**
+	 * Downloads the source files and import the translations.
+	 *
+	 * @access private
+	 *
+	 * @param GP_Project $project          The GlotPress Project to extract.
+	 * @param Array      $project_settings Array of Project Settings.
+	 * @param Array      $format_message   Optional. If the message should be wrapped by html. Default true.
+	 * @return String Message.
+	 */
 	private function extract_project( $project, $project_settings, $format_message = true ) {
 		$url_name = sprintf(
 			$this->source_type_templates[ $project_settings[ $project->id ]['type'] ],
@@ -191,20 +271,20 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 		$message = '';
 
-		if( ! is_wp_error( $source_file ) ) {
+		if ( ! is_wp_error( $source_file ) ) {
 
 			include( dirname( __FILE__ ) . '/include/extract/makepot.php' );
 
 			// Get a temporary file, use gpa as the first four letters of it.
-			$temp_dir = tempnam( sys_get_temp_dir(), 'gpa');
-			$temp_pot = tempnam( sys_get_temp_dir(), 'gpa');
+			$temp_dir = tempnam( sys_get_temp_dir(), 'gpa' );
+			$temp_pot = tempnam( sys_get_temp_dir(), 'gpa' );
 
 			// Now delete the file and recreate it as a directory.
 			unlink( $temp_dir );
 			mkdir( $temp_dir );
 
 			$zip = new ZipArchive;
-			if ( $zip->open( $source_file ) === TRUE ) {
+			if ( true === $zip->open( $source_file ) ) {
 				$zip->extractTo( $temp_dir );
 				$zip->close();
 
@@ -212,7 +292,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			} else {
 				unlink( $source_file );
 
-				return '<div class="notice updated"><p>' . sprintf( __('Failed to extract zip file: "%s".' ), $source_file ) . '</p></div>';
+				return '<div class="notice updated"><p>' . esc_html( sprintf( __( 'Failed to extract zip file: "%s".' ), $source_file ) ) . '</p></div>';
 			}
 
 			$src_dir = $temp_dir;
@@ -221,8 +301,8 @@ class GP_Auto_Extract extends GP_Route_Main {
 			$src_files = scandir( $src_dir );
 
 			// If there are exactly three files in the list ( '.', '..' and something else ) then check the third one and if it's a directory, make it he new $src_dir.
-			if( count( $src_files ) == 3 ) {
-				if( is_dir( $src_dir . '/' . $src_files[2] ) ) {
+			if ( 3 === count( $src_files ) ) {
+				if ( is_dir( $src_dir . '/' . $src_files[2] ) ) {
 					$src_dir .= '/' . $src_files[2];
 				}
 			}
@@ -235,7 +315,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 				$format = gp_array_get( GP::$formats, $import_format, null );
 
-				$pot_file = $format->read_originals_from_file( $src_dir . ( $import_file[0] == '/' ? '' : '/' ) . $import_file );
+				$pot_file = $format->read_originals_from_file( $src_dir . ( '/' === $import_file[0] ? '' : '/' ) . $import_file );
 
 			} else {
 
@@ -258,36 +338,36 @@ class GP_Auto_Extract extends GP_Route_Main {
 			$this->delTree( $temp_dir );
 			unlink( $temp_pot );
 
-			if( FALSE === $translations ) {
-				return '<div class="notice updated"><p>' . __( 'Failed to read strings from source code.' ) . '</p></div>';
+			if ( false === $translations ) {
+				return '<div class="notice updated"><p>' . esc_html__( 'Failed to read strings from source code.' ) . '</p></div>';
 			}
 
 			list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted ) = GP::$original->import_for_project( $project, $translations );
 
-			if( true === $format_message ) {
+			if ( true === $format_message ) {
 				$message .= '<div class="notice updated"><p>';
 			}
 
-			$message .= sprintf(
+			$message .= esc_html( sprintf(
 				__( '%1$s new strings added, %2$s updated, %3$s fuzzied, and %4$s obsoleted in the "%5$s" project.' ),
 				$originals_added,
 				$originals_existing,
 				$originals_fuzzied,
 				$originals_obsoleted,
 				$project->name
-			);
+			) );
 
-			if( true === $format_message ) {
+			if ( true === $format_message ) {
 				$message .= '</p></div>';
 			}
 		} else {
-			if( true === $format_message ) {
+			if ( true === $format_message ) {
 				$message .= '<div class="notice updated"><p>';
 			}
 
-			$message .= sprintf( __('Failed to download "%s".' ), $url_name ) . '</p></div>';
+			$message .= esc_html( sprintf( __( 'Failed to download "%s".' ), $url_name ) ) . '</p></div>';
 
-			if( true === $format_message ) {
+			if ( true === $format_message ) {
 				$message .= '</p></div>';
 			}
 		}
@@ -295,10 +375,15 @@ class GP_Auto_Extract extends GP_Route_Main {
 		return $message;
 	}
 
-	// This function displays the admin settings page in WordPress.
+	/**
+	 * This function displays the admin settings page in WordPress.
+	 */
 	public function admin_page() {
 		// If the current user can't manage options, display a message and return immediately.
-		if( ! current_user_can( 'manage_options' ) ) { _e('You do not have permissions to this page!'); return; }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			esc_html_e( 'You do not have permissions to this page!' );
+			return;
+		}
 
 		$empty_project = array(
 			'type' => 'none',
@@ -312,67 +397,76 @@ class GP_Auto_Extract extends GP_Route_Main {
 			'import_file' => '',
 		);
 
-
 		$projects = GP::$project->all();
 
 		$message = '';
 
-		$project_settings = (array)get_option( 'gp_auto_extract', array() );
+		$project_settings = (array) get_option( 'gp_auto_extract', array() );
 
-		foreach( $projects as $project ) {
-			if( array_key_exists( 'save_' . $project->id, $_POST ) ) {
-				$project_settings[ $project->id ]['type']                = filter_input( INPUT_POST, 'source_type_' . $project->id );
-				$project_settings[ $project->id ]['setting']             = filter_input( INPUT_POST, 'setting_' . $project->id );
-				$project_settings[ $project->id ]['branch']              = filter_input( INPUT_POST, 'branch_' . $project->id );
-				$project_settings[ $project->id ]['use_http_basic_auth'] = filter_input( INPUT_POST, 'use_http_basic_auth_' . $project->id );
-				$project_settings[ $project->id ]['http_auth_username']  = filter_input( INPUT_POST, 'http_auth_username_' . $project->id );
-				$project_settings[ $project->id ]['http_auth_password']  = filter_input( INPUT_POST, 'http_auth_password_' . $project->id );
-				$project_settings[ $project->id ]['skip_makepot']        = filter_input( INPUT_POST, 'skip_makepot_' . $project->id );
-				$project_settings[ $project->id ]['import_format']       = filter_input( INPUT_POST, 'import_format_' . $project->id );
-				$project_settings[ $project->id ]['import_file']         = filter_input( INPUT_POST, 'import_file_' . $project->id );
+		if ( 'POST' === filter_var( $_SERVER['REQUEST_METHOD'] ) ) {
+			check_admin_referer( 'gp-auto-extract' );
 
-				update_option( 'gp_auto_extract', $project_settings );
-			}
+			foreach ( $projects as $project ) {
 
-			if( array_key_exists( 'delete_' . $project->id, $_POST ) ) {
-				$project_settings[ $project->id ] = $empty_project;
+				if ( array_key_exists( 'save_' . $project->id, $_POST ) ) {
+					$project_settings[ $project->id ]['type']                = filter_input( INPUT_POST, 'source_type_' . $project->id );
+					$project_settings[ $project->id ]['setting']             = filter_input( INPUT_POST, 'setting_' . $project->id );
+					$project_settings[ $project->id ]['branch']              = filter_input( INPUT_POST, 'branch_' . $project->id );
+					$project_settings[ $project->id ]['use_http_basic_auth'] = filter_input( INPUT_POST, 'use_http_basic_auth_' . $project->id );
+					$project_settings[ $project->id ]['http_auth_username']  = filter_input( INPUT_POST, 'http_auth_username_' . $project->id );
+					$project_settings[ $project->id ]['http_auth_password']  = filter_input( INPUT_POST, 'http_auth_password_' . $project->id );
+					$project_settings[ $project->id ]['skip_makepot']        = filter_input( INPUT_POST, 'skip_makepot_' . $project->id );
+					$project_settings[ $project->id ]['import_format']       = filter_input( INPUT_POST, 'import_format_' . $project->id );
+					$project_settings[ $project->id ]['import_file']         = filter_input( INPUT_POST, 'import_file_' . $project->id );
 
-				update_option( 'gp_auto_extract', $project_settings );
-			}
+					update_option( 'gp_auto_extract', $project_settings );
+				}
 
-			if( array_key_exists( 'extract_' . $project->id, $_POST ) ) {
-				if( 'none' != $project_settings[ $project->id ][ 'type' ] ) {
-					$message = $this->extract_project( $project, $project_settings );
-				} else {
-					$message = '<div class="notice error"><p>' . sprintf( __('No source type selected for project "%s".' ), $project->name ) . '</p></div>';
+				if ( array_key_exists( 'delete_' . $project->id, $_POST ) ) {
+					$project_settings[ $project->id ] = $empty_project;
+
+					update_option( 'gp_auto_extract', $project_settings );
+				}
+
+				if ( array_key_exists( 'extract_' . $project->id, $_POST ) ) {
+					if ( 'none' !== $project_settings[ $project->id ]['type'] ) {
+						$message = $this->extract_project( $project, $project_settings );
+					} else {
+						$message = '<div class="notice error"><p>' . esc_html( sprintf( __( 'No source type selected for project "%s".' ), $project->name ) ) . '</p></div>';
+					}
 				}
 			}
 		}
 	?>
 <div class="wrap">
-	<?php echo $message; ?>
+	<?php
+	// @codingStandardsIgnoreStart
+	echo $message;
+	// @codingStandardsIgnoreEnd
+	?>
 
-	<h2><?php _e('GP Auto Extract Settings'); ?></h2>
+	<h2><?php esc_html_e( 'GP Auto Extract Settings' ); ?></h2>
 
 	<br />
 
 	<form method="post" id="gp-auto-extract" action="options-general.php?page=gp-auto-extract.php" >
+		<?php wp_nonce_field( 'gp-auto-extract' ); ?>
 
 		<table class="widefat striped">
 			<thead>
 			<tr>
-				<th><?php _e( 'Project' ); ?></th>
-				<th><?php _e( 'Source Type' ); ?></th>
-				<th><?php _e( 'Setting' ); ?></th>
-				<th><?php _e( 'Branch' ); ?></th>
-				<th><?php _e( 'Authorization' ); ?></th>
+				<th><?php esc_html_e( 'Project' ); ?></th>
+				<th><?php esc_html_e( 'Source Type' ); ?></th>
+				<th><?php esc_html_e( 'Setting' ); ?></th>
+				<th><?php esc_html_e( 'Branch' ); ?></th>
+				<th><?php esc_html_e( 'Authorization' ); ?></th>
 			</tr>
 			</thead>
 
 			<tbody id="the-list">
 
-<?php
-	foreach( $projects as $project ) {
+	<?php
+	foreach ( $projects as $project ) {
 		$source_type = 'none';
 		$setting = '';
 
@@ -394,28 +488,28 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 		$row_actions = '';
 		$row_actions .= sprintf(
-			'<span class="edit"><a href="#" class="editinline" data-project-id="%s" aria-label="%s">%s</a></span>',
-			$project->id,
+			'<span class="edit"><a href="" class="editinline" data-project-id="%s" aria-label="%s">%s</a></span>',
+			esc_attr( $project->id ),
 			/* translators: %s: project name */
 			esc_attr( sprintf( __( 'Edit project &#8220;%s&#8221;' ), $project->name ) ),
-			__( 'Edit' )
+			esc_html__( 'Edit' )
 		);
 
-		if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
+		if ( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings ) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' !== $project_settings[ $project->id ]['type'] ) {
 			$row_actions .= sprintf(
-				' | <span class="trash"><a href="#" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
-				$project->id,
+				' | <span class="trash"><a href="" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
+				esc_attr( $project->id ),
 				/* translators: %s: project name */
 				esc_attr( sprintf( __( 'Reset &#8220;%s&#8221;' ), $project->name ) ),
-				__( 'Reset' )
+				esc_html__( 'Reset' )
 			);
 
 			$row_actions .= sprintf(
-				' | <span class="extract"><a href="#" class="extract-project" id="extract_%s" aria-label="%s">%s</a></span>',
-				$project->id,
+				' | <span class="extract"><a href="" class="extract-project" id="extract_%s" aria-label="%s">%s</a></span>',
+				esc_attr( $project->id ),
 				/* translators: %s: project name */
 				esc_attr( sprintf( __( 'Extract &#8220;%s&#8221;' ), $project->name ) ),
-				__( 'Extract' )
+				esc_html__( 'Extract' )
 			);
 		}
 
@@ -437,7 +531,13 @@ class GP_Auto_Extract extends GP_Route_Main {
 				<tr id="project-<?php echo esc_attr( $project->id ); ?>">
 					<td class="title column-title has-row-actions column-primary">
 						<strong><?php echo esc_html( $project->name ); ?></strong>
-						<div class="row-actions"><?php echo $row_actions; ?></div>
+						<div class="row-actions">
+							<?php
+							// @codingStandardsIgnoreStart
+							echo $row_actions;
+							// @codingStandardsIgnoreEnd
+							?>
+						</div>
 					</td>
 					<td><?php echo esc_html( $this->source_types[ $source_type ] ); ?></td>
 					<td><?php echo esc_html( $setting ); ?></td>
@@ -448,14 +548,14 @@ class GP_Auto_Extract extends GP_Route_Main {
 				<tr id="edit-project-<?php echo esc_attr( $project->id ); ?>" class="source-type-<?php echo esc_attr( $source_type ); ?> hidden inline-edit-row inline-edit-row-page inline-edit-page quick-edit-row quick-edit-row-page inline-edit-page inline-editor">
 					<td colspan="5" class="colspanchange">
 						<fieldset class="inline-edit-col-left">
-							<legend class="inline-edit-legend"><?php echo esc_html__( 'Edit' ); ?></legend>
+							<legend class="inline-edit-legend"><?php esc_html_e( 'Edit' ); ?></legend>
 							<div class="inline-edit-col">
 								<label>
-									<span class="title"><?php echo esc_html__( 'Project' ); ?></span>
+									<span class="title"><?php esc_html_e( 'Project' ); ?></span>
 									<span class="input-text-wrap"><strong><?php echo esc_html( $project->name ); ?></strong></span>
 								</label>
 								<label>
-									<span class="title"><?php echo esc_html__( 'Source Type' ); ?></span>
+									<span class="title"><?php esc_html_e( 'Source Type' ); ?></span>
 									<select class="source_type" name="source_type_<?php echo esc_attr( $project->id ); ?>" id="source_type_<?php echo esc_attr( $project->id ); ?>">
 									<?php foreach ( $this->source_types as $id => $type ) { ?>
 										<option value="<?php echo esc_attr( $id ); ?>" <?php echo selected( $source_type, $id ); ?>><?echo esc_html( $type ); ?></option>;
@@ -463,28 +563,28 @@ class GP_Auto_Extract extends GP_Route_Main {
 									</select>
 								</label>
 								<label class="hide-if-none">
-									<span class="title"><?php echo esc_html__( 'Setting' ); ?></span>
+									<span class="title"><?php esc_html_e( 'Setting' ); ?></span>
 									<span class="input-text-wrap"><input type="text" class="gpae-setting" name="setting_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $setting ); ?>"></span>
 								</label>
 								<div class="inline-edit-group wp-clearfix show-if-github">
 									<label class="alignleft">
-										<span class="title"><?php echo esc_html__( 'Branch/Tag' ); ?></span>
+										<span class="title"><?php esc_html_e( 'Branch/Tag' ); ?></span>
 										<span class="input-text-wrap"><input type="text" name="branch_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $branch ); ?>" placeholder="master"></span>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress">
 									<label class="alignleft">
 										<input type="checkbox" name="use_http_basic_auth_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $use_http_basic_auth, 'on' ); ?> class="group-toggle" data-group="httpauth-<?php echo esc_attr( $project->id ); ?>">
-										<span class="checkbox-title"><?php echo esc_html__( 'Use HTTP Basic Authentication' ); ?></span>
+										<span class="checkbox-title"><?php esc_html_e( 'Use HTTP Basic Authentication' ); ?></span>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress hidden group-httpauth-<?php echo esc_attr( $project->id ); ?>">
 									<label class="alignleft">
-										<span class="title"><?php echo esc_html__( 'Username' ); ?></span>
+										<span class="title"><?php esc_html_e( 'Username' ); ?></span>
 										<span class="input-text-wrap"><input type="text" name="http_auth_username_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $http_auth_username ); ?>"></span>
 									</label>
 									<label class="alignleft">
-										<span class="title"><?php echo esc_html__( 'Password' ); ?></span>
+										<span class="title"><?php esc_html_e( 'Password' ); ?></span>
 										<span class="input-text-wrap"><input type="text" class="gpae-password" name="http_auth_password_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $http_auth_password ); ?>"></span>
 									</label>
 								</div>
@@ -495,32 +595,34 @@ class GP_Auto_Extract extends GP_Route_Main {
 								<div class="inline-edit-group wp-clearfix hide-if-none">
 									<label class="alignleft">
 										<input type="checkbox" name="skip_makepot_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $skip_makepot, 'on' ); ?> class="group-toggle" data-group="makepot-<?php echo esc_attr( $project->id ); ?>">
-										<span class="checkbox-title"><?php echo esc_html__( 'Import from existing file' ); ?></span>
+										<span class="checkbox-title"><?php esc_html_e( 'Import from existing file' ); ?></span>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
 									<label class="alignleft">
-										<span class="title"><?php echo esc_html__( 'Format' ); ?></span>
+										<span class="title"><?php esc_html_e( 'Format' ); ?></span>
 										<?php
 										$format_options = array();
 										foreach ( GP::$formats as $slug => $format ) {
 											$format_options[ $slug ] = $format->name;
 										}
+										// @codingStandardsIgnoreStart
 										echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'po' );
+										// @codingStandardsIgnoreEnd
 										?>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
 									<label>
-										<span class="title"><?php echo esc_html__( 'File' ); ?></span>
-										<span class="input-text-wrap"><input type="text" name="import_file_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $import_file ); ?>" placeholder="<?php echo esc_attr__( 'path of file to import relative to repository or archive root' ); ?>"></span>
+										<span class="title"><?php esc_html_e( 'File' ); ?></span>
+										<span class="input-text-wrap"><input type="text" name="import_file_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $import_file ); ?>" placeholder="<?php esc_attr_e( 'path of file to import relative to repository or archive root' ); ?>"></span>
 									</label>
 								</div>
 							</div>
 						</fieldset>
 						<p class="submit inline-edit-save">
-							<button type="button" class="button cancel alignleft" data-project-id="<? echo esc_attr( $project->id ); ?>"><?php echo esc_html( __( 'Cancel' ) ); ?></button>
-							<input type="submit" name="save_<?php echo esc_attr( $project->id ); ?>" class="button button-primary save alignright" value="<?php echo esc_attr( __( 'Save' ) ); ?>"/>
+							<button type="button" class="button cancel alignleft" data-project-id="<? echo esc_attr( $project->id ); ?>"><?php esc_html_e( 'Cancel' ); ?></button>
+							<input type="submit" name="save_<?php echo esc_attr( $project->id ); ?>" class="button button-primary save alignright" value="<?php esc_attr_e( 'Save' ); ?>"/>
 							<br class="clear">
 						</p>
 					</td>
@@ -541,9 +643,11 @@ class GP_Auto_Extract extends GP_Route_Main {
 // Add an action to WordPress's init hook to setup the plugin.  Don't just setup the plugin here as the GlotPress plugin may not have loaded yet.
 add_action( 'gp_init', 'gp_auto_extract_init' );
 
-// This function creates the plugin.
+/**
+ * This function creates the plugin.
+ */
 function gp_auto_extract_init() {
-	GLOBAL $gp_auto_extract;
+	global $gp_auto_extract;
 
 	$gp_auto_extract = new GP_Auto_Extract;
 }

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -376,19 +376,21 @@ class GP_Auto_Extract extends GP_Route_Main {
 		$source_type = 'none';
 		$setting = '';
 
-		if( array_key_exists( $project->id, $project_settings ) ) {
+		if ( array_key_exists( $project->id, $project_settings ) ) {
 			$current_project = $project_settings[ $project->id ];
-
-			$source_type         = array_key_exists( 'type', $current_project ) ? $current_project['type'] : 'none';
-			$setting             = array_key_exists( 'setting', $current_project ) ? $current_project['setting'] : '';
-			$branch              = array_key_exists( 'branch', $current_project ) ? $current_project['branch'] : '';
-			$use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
-			$http_auth_username  = array_key_exists( 'http_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
-			$http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
-			$skip_makepot        = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
-			$import_format       = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
-			$import_file         = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
+		} else {
+			$current_project = $empty_project;
 		}
+
+		$source_type         = array_key_exists( 'type', $current_project ) ? $current_project['type'] : 'none';
+		$setting             = array_key_exists( 'setting', $current_project ) ? $current_project['setting'] : '';
+		$branch              = array_key_exists( 'branch', $current_project ) ? $current_project['branch'] : '';
+		$use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
+		$http_auth_username  = array_key_exists( 'http_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
+		$http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
+		$skip_makepot        = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
+		$import_format       = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
+		$import_file         = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
 
 		$row_actions = '';
 		$row_actions .= sprintf(

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -319,15 +319,15 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 		foreach( $projects as $project ) {
 			if( array_key_exists( 'save_' . $project->id, $_POST ) ) {
-				$project_settings[ $project->id ]['type']                = $_POST[ 'source_type_' . $project->id ];
-				$project_settings[ $project->id ]['setting']             = $_POST[ 'setting_' . $project->id ];
-                $project_settings[ $project->id ]['branch']              = $_POST[ 'branch_' . $project->id ];
-                $project_settings[ $project->id ]['use_http_basic_auth'] = $_POST[ 'use_http_basic_auth_' . $project->id ];
-                $project_settings[ $project->id ]['http_auth_username']  = $_POST[ 'http_auth_username_' . $project->id ];
-                $project_settings[ $project->id ]['http_auth_password']  = $_POST[ 'http_auth_password_' . $project->id ];
-                $project_settings[ $project->id ]['skip_makepot']        = $_POST[ 'skip_makepot_' . $project->id ];
-                $project_settings[ $project->id ]['import_format']       = $_POST[ 'import_format_' . $project->id ];
-                $project_settings[ $project->id ]['import_file']         = $_POST[ 'import_file_' . $project->id ];
+				$project_settings[ $project->id ]['type']                = filter_input( INPUT_POST, 'source_type_' . $project->id );
+				$project_settings[ $project->id ]['setting']             = filter_input( INPUT_POST, 'setting_' . $project->id );
+                $project_settings[ $project->id ]['branch']              = filter_input( INPUT_POST, 'branch_' . $project->id );
+                $project_settings[ $project->id ]['use_http_basic_auth'] = filter_input( INPUT_POST, 'use_http_basic_auth_' . $project->id );
+                $project_settings[ $project->id ]['http_auth_username']  = filter_input( INPUT_POST, 'http_auth_username_' . $project->id );
+                $project_settings[ $project->id ]['http_auth_password']  = filter_input( INPUT_POST, 'http_auth_password_' . $project->id );
+                $project_settings[ $project->id ]['skip_makepot']        = filter_input( INPUT_POST, 'skip_makepot_' . $project->id );
+                $project_settings[ $project->id ]['import_format']       = filter_input( INPUT_POST, 'import_format_' . $project->id );
+                $project_settings[ $project->id ]['import_file']         = filter_input( INPUT_POST, 'import_file_' . $project->id );
 
 				update_option( 'gp_auto_extract', $project_settings );
 			}

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -115,13 +115,6 @@ class GP_Auto_Extract extends GP_Route_Main {
 	}
 
 	/**
-	 * This function is here as placeholder to support adding the auto extract option to the router.
-	 * Without this placeholder there is a fatal error generated.
-	 */
-	public function before_request() {
-	}
-
-	/**
 	 * This function handles the actual auto extract passed in by the router for the projects menu.
 	 *
 	 * @param String $project_path The url path to the project.
@@ -159,13 +152,6 @@ class GP_Auto_Extract extends GP_Route_Main {
 	}
 
 	/**
-	 * This function is here as placeholder to support adding the auto extract option to the router.
-	 * Without this placeholder there is a fatal error generated.
-	 */
-	public function after_request() {
-	}
-
-	/**
 	 * This function adds the "Auto Extract" option to the projects menu.
 	 *
 	 * @param Array      $actions Array containing project actions.
@@ -176,7 +162,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 		$project_settings = (array) get_option( 'gp_auto_extract', array() );
 
 		if ( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings ) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' !== $project_settings[ $project->id ]['type'] ) {
-			$actions[] .= gp_link_get( gp_url( 'auto-extract/' . $project->slug ), esc_html__( 'Auto Extract' ) );
+			$actions[] .= gp_link_get( gp_url( 'auto-extract/' . $project->slug ), __( 'Auto Extract' ) );
 		}
 
 		return $actions;
@@ -212,7 +198,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 	 * This function adds the admin settings page to WordPress.
 	 */
 	public function admin_menu() {
-		add_options_page( esc_html__( 'GP Auto Extract' ), esc_html__( 'GP Auto Extract' ), 'manage_options', basename( __FILE__ ), array( $this, 'admin_page' ) );
+		add_options_page( __( 'GP Auto Extract' ), __( 'GP Auto Extract' ), 'manage_options', basename( __FILE__ ), array( $this, 'admin_page' ) );
 	}
 
 	/**
@@ -292,7 +278,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			} else {
 				unlink( $source_file );
 
-				return '<div class="notice updated"><p>' . esc_html( sprintf( __( 'Failed to extract zip file: "%s".' ), $source_file ) ) . '</p></div>';
+				return '<div class="notice updated"><p>' . sprintf( __( 'Failed to extract zip file: "%s".' ), $source_file ) . '</p></div>';
 			}
 
 			$src_dir = $temp_dir;
@@ -339,7 +325,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			unlink( $temp_pot );
 
 			if ( false === $translations ) {
-				return '<div class="notice updated"><p>' . esc_html__( 'Failed to read strings from source code.' ) . '</p></div>';
+				return '<div class="notice updated"><p>' . __( 'Failed to read strings from source code.' ) . '</p></div>';
 			}
 
 			list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted ) = GP::$original->import_for_project( $project, $translations );
@@ -348,14 +334,14 @@ class GP_Auto_Extract extends GP_Route_Main {
 				$message .= '<div class="notice updated"><p>';
 			}
 
-			$message .= esc_html( sprintf(
+			$message .= sprintf(
 				__( '%1$s new strings added, %2$s updated, %3$s fuzzied, and %4$s obsoleted in the "%5$s" project.' ),
 				$originals_added,
 				$originals_existing,
 				$originals_fuzzied,
 				$originals_obsoleted,
 				$project->name
-			) );
+			);
 
 			if ( true === $format_message ) {
 				$message .= '</p></div>';
@@ -365,7 +351,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 				$message .= '<div class="notice updated"><p>';
 			}
 
-			$message .= esc_html( sprintf( __( 'Failed to download "%s".' ), $url_name ) ) . '</p></div>';
+			$message .= sprintf( __( 'Failed to download "%s".' ), $url_name ) . '</p></div>';
 
 			if ( true === $format_message ) {
 				$message .= '</p></div>';
@@ -381,7 +367,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 	public function admin_page() {
 		// If the current user can't manage options, display a message and return immediately.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			esc_html_e( 'You do not have permissions to this page!' );
+			_e( 'You do not have permissions to this page!' );
 			return;
 		}
 
@@ -432,20 +418,16 @@ class GP_Auto_Extract extends GP_Route_Main {
 					if ( 'none' !== $project_settings[ $project->id ]['type'] ) {
 						$message = $this->extract_project( $project, $project_settings );
 					} else {
-						$message = '<div class="notice error"><p>' . esc_html( sprintf( __( 'No source type selected for project "%s".' ), $project->name ) ) . '</p></div>';
+						$message = '<div class="notice error"><p>' . sprintf( __( 'No source type selected for project "%s".' ), $project->name ) . '</p></div>';
 					}
 				}
 			}
 		}
 	?>
 <div class="wrap">
-	<?php
-	// @codingStandardsIgnoreStart
-	echo $message;
-	// @codingStandardsIgnoreEnd
-	?>
+	<?php echo $message; ?>
 
-	<h2><?php esc_html_e( 'GP Auto Extract Settings' ); ?></h2>
+	<h2><?php _e( 'GP Auto Extract Settings' ); ?></h2>
 
 	<br />
 
@@ -455,11 +437,11 @@ class GP_Auto_Extract extends GP_Route_Main {
 		<table class="widefat striped">
 			<thead>
 			<tr>
-				<th><?php esc_html_e( 'Project' ); ?></th>
-				<th><?php esc_html_e( 'Source Type' ); ?></th>
-				<th><?php esc_html_e( 'Setting' ); ?></th>
-				<th><?php esc_html_e( 'Branch' ); ?></th>
-				<th><?php esc_html_e( 'Authorization' ); ?></th>
+				<th><?php _e( 'Project' ); ?></th>
+				<th><?php _e( 'Source Type' ); ?></th>
+				<th><?php _e( 'Setting' ); ?></th>
+				<th><?php _e( 'Branch' ); ?></th>
+				<th><?php _e( 'Authorization' ); ?></th>
 			</tr>
 			</thead>
 
@@ -492,7 +474,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			esc_attr( $project->id ),
 			/* translators: %s: project name */
 			esc_attr( sprintf( __( 'Edit project &#8220;%s&#8221;' ), $project->name ) ),
-			esc_html__( 'Edit' )
+			__( 'Edit' )
 		);
 
 		if ( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings ) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' !== $project_settings[ $project->id ]['type'] ) {
@@ -501,7 +483,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 				esc_attr( $project->id ),
 				/* translators: %s: project name */
 				esc_attr( sprintf( __( 'Reset &#8220;%s&#8221;' ), $project->name ) ),
-				esc_html__( 'Reset' )
+				__( 'Reset' )
 			);
 
 			$row_actions .= sprintf(
@@ -509,7 +491,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 				esc_attr( $project->id ),
 				/* translators: %s: project name */
 				esc_attr( sprintf( __( 'Extract &#8220;%s&#8221;' ), $project->name ) ),
-				esc_html__( 'Extract' )
+				__( 'Extract' )
 			);
 		}
 
@@ -533,58 +515,56 @@ class GP_Auto_Extract extends GP_Route_Main {
 						<strong><?php echo esc_html( $project->name ); ?></strong>
 						<div class="row-actions">
 							<?php
-							// @codingStandardsIgnoreStart
 							echo $row_actions;
-							// @codingStandardsIgnoreEnd
 							?>
 						</div>
 					</td>
-					<td><?php echo esc_html( $this->source_types[ $source_type ] ); ?></td>
+					<td><?php echo $this->source_types[ $source_type ]; ?></td>
 					<td><?php echo esc_html( $setting ); ?></td>
-					<td><?php echo esc_html( $branch_label ); ?></td>
-					<td><?php echo esc_html( $use_http_basic_auth_label ); ?></td>
+					<td><?php echo $branch_label; ?></td>
+					<td><?php echo $use_http_basic_auth_label; ?></td>
 				</tr>
 				<tr class="hidden"></tr>
 				<tr id="edit-project-<?php echo esc_attr( $project->id ); ?>" class="source-type-<?php echo esc_attr( $source_type ); ?> hidden inline-edit-row inline-edit-row-page inline-edit-page quick-edit-row quick-edit-row-page inline-edit-page inline-editor">
 					<td colspan="5" class="colspanchange">
 						<fieldset class="inline-edit-col-left">
-							<legend class="inline-edit-legend"><?php esc_html_e( 'Edit' ); ?></legend>
+							<legend class="inline-edit-legend"><?php _e( 'Edit' ); ?></legend>
 							<div class="inline-edit-col">
 								<label>
-									<span class="title"><?php esc_html_e( 'Project' ); ?></span>
+									<span class="title"><?php _e( 'Project' ); ?></span>
 									<span class="input-text-wrap"><strong><?php echo esc_html( $project->name ); ?></strong></span>
 								</label>
 								<label>
-									<span class="title"><?php esc_html_e( 'Source Type' ); ?></span>
+									<span class="title"><?php _e( 'Source Type' ); ?></span>
 									<select class="source_type" name="source_type_<?php echo esc_attr( $project->id ); ?>" id="source_type_<?php echo esc_attr( $project->id ); ?>">
 									<?php foreach ( $this->source_types as $id => $type ) { ?>
-										<option value="<?php echo esc_attr( $id ); ?>" <?php echo selected( $source_type, $id ); ?>><?echo esc_html( $type ); ?></option>;
+										<option value="<?php echo esc_attr( $id ); ?>" <?php echo selected( $source_type, $id ); ?>><?php echo $type; ?></option>;
 									<?php } ?>
 									</select>
 								</label>
 								<label class="hide-if-none">
-									<span class="title"><?php esc_html_e( 'Setting' ); ?></span>
+									<span class="title"><?php _e( 'Setting' ); ?></span>
 									<span class="input-text-wrap"><input type="text" class="gpae-setting" name="setting_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $setting ); ?>"></span>
 								</label>
 								<div class="inline-edit-group wp-clearfix show-if-github">
 									<label class="alignleft">
-										<span class="title"><?php esc_html_e( 'Branch/Tag' ); ?></span>
+										<span class="title"><?php _e( 'Branch/Tag' ); ?></span>
 										<span class="input-text-wrap"><input type="text" name="branch_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $branch ); ?>" placeholder="master"></span>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress">
 									<label class="alignleft">
 										<input type="checkbox" name="use_http_basic_auth_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $use_http_basic_auth, 'on' ); ?> class="group-toggle" data-group="httpauth-<?php echo esc_attr( $project->id ); ?>">
-										<span class="checkbox-title"><?php esc_html_e( 'Use HTTP Basic Authentication' ); ?></span>
+										<span class="checkbox-title"><?php _e( 'Use HTTP Basic Authentication' ); ?></span>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress hidden group-httpauth-<?php echo esc_attr( $project->id ); ?>">
 									<label class="alignleft">
-										<span class="title"><?php esc_html_e( 'Username' ); ?></span>
+										<span class="title"><?php _e( 'Username' ); ?></span>
 										<span class="input-text-wrap"><input type="text" name="http_auth_username_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $http_auth_username ); ?>"></span>
 									</label>
 									<label class="alignleft">
-										<span class="title"><?php esc_html_e( 'Password' ); ?></span>
+										<span class="title"><?php _e( 'Password' ); ?></span>
 										<span class="input-text-wrap"><input type="text" class="gpae-password" name="http_auth_password_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $http_auth_password ); ?>"></span>
 									</label>
 								</div>
@@ -595,33 +575,31 @@ class GP_Auto_Extract extends GP_Route_Main {
 								<div class="inline-edit-group wp-clearfix hide-if-none">
 									<label class="alignleft">
 										<input type="checkbox" name="skip_makepot_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $skip_makepot, 'on' ); ?> class="group-toggle" data-group="makepot-<?php echo esc_attr( $project->id ); ?>">
-										<span class="checkbox-title"><?php esc_html_e( 'Import from existing file' ); ?></span>
+										<span class="checkbox-title"><?php _e( 'Import from existing file' ); ?></span>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
 									<label class="alignleft">
-										<span class="title"><?php esc_html_e( 'Format' ); ?></span>
+										<span class="title"><?php _e( 'Format' ); ?></span>
 										<?php
 										$format_options = array();
 										foreach ( GP::$formats as $slug => $format ) {
 											$format_options[ $slug ] = $format->name;
 										}
-										// @codingStandardsIgnoreStart
 										echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'po' );
-										// @codingStandardsIgnoreEnd
 										?>
 									</label>
 								</div>
 								<div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
 									<label>
-										<span class="title"><?php esc_html_e( 'File' ); ?></span>
+										<span class="title"><?php _e( 'File' ); ?></span>
 										<span class="input-text-wrap"><input type="text" name="import_file_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $import_file ); ?>" placeholder="<?php esc_attr_e( 'path of file to import relative to repository or archive root' ); ?>"></span>
 									</label>
 								</div>
 							</div>
 						</fieldset>
 						<p class="submit inline-edit-save">
-							<button type="button" class="button cancel alignleft" data-project-id="<? echo esc_attr( $project->id ); ?>"><?php esc_html_e( 'Cancel' ); ?></button>
+							<button type="button" class="button cancel alignleft" data-project-id="<?php echo esc_attr( $project->id ); ?>"><?php _e( 'Cancel' ); ?></button>
 							<input type="submit" name="save_<?php echo esc_attr( $project->id ); ?>" class="button button-primary save alignright" value="<?php esc_attr_e( 'Save' ); ?>"/>
 							<br class="clear">
 						</p>

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -23,22 +23,22 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 class GP_Auto_Extract extends GP_Route_Main {
 	public $id = 'gp-auto-extract';
 
-	private	$source_types;
+	private $source_types;
 	private $source_type_templates;
-    private $url_credentials = array();
+	private $url_credentials = array();
 
 	public function __construct() {
 		$this->source_types = array( 'none' => __( 'none' ), 'github' => __( 'GitHub' ), 'wordpress' => __( 'WordPress.org' ), 'custom' => __( 'Custom' ) );
 		$this->source_type_templates = array(
-											'none' 		=> '',
-											'github' 	=> 'https://github.com/%s/archive/%s.zip',
-											'wordpress' => 'https://downloads.wordpress.org/plugin/%s.zip',
-											'custom' 	=> '%s',
-										);
+			'none'      => '',
+			'github'    => 'https://github.com/%s/archive/%s.zip',
+			'wordpress' => 'https://downloads.wordpress.org/plugin/%s.zip',
+			'custom'    => '%s',
+		);
 
 		// Add the admin page to the WordPress settings menu.
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 10, 1 );
-        add_action( 'admin_enqueue_scripts', array( $this, 'load_custom_wp_admin_style' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'load_custom_wp_admin_style' ) );
 
 		// If the user has write permissions to the projects, add the auto extract option to the projects menu.
 		if( GP::$permission->user_can( wp_get_current_user(), 'write', 'project' ) ) {
@@ -52,29 +52,29 @@ class GP_Auto_Extract extends GP_Route_Main {
 	}
 
 	public function load_custom_wp_admin_style( $hook ) {
-            // Load only on ?page=gp-auto-extract.php
-            if ( $hook != 'settings_page_gp-auto-extract' ) {
-                return;
-            }
-            wp_enqueue_style( 'gp-auto-extract-css', plugins_url('assets/css/gp-auto-extract.css', __FILE__) );
+			// Load only on ?page=gp-auto-extract.php
+			if ( $hook != 'settings_page_gp-auto-extract' ) {
+				return;
+			}
+			wp_enqueue_style( 'gp-auto-extract-css', plugins_url('assets/css/gp-auto-extract.css', __FILE__) );
 
-            wp_register_script( 'gp-auto-extract-js', plugins_url('assets/js/gp-auto-extract.js', __FILE__) );
-            $translation_array = array(
-                'passwords' => array(
-                    'none' => '',
-                    'github' => __( 'or Personal Access Token' ),
-                    'wordpress' => '',
-                    'custom' => '',
-                ),
-                'settings' => array(
-                    'none' => '',
-                    'github' => __( 'username/repository' ),
-                    'wordpress' => __( 'plugin-or-theme-slug' ),
-                    'custom' => __( 'url for a valid archive with source files' ),
-                ),
-            );
-            wp_localize_script( 'gp-auto-extract-js', 'gpae', $translation_array );
-            wp_enqueue_script( 'gp-auto-extract-js' );
+			wp_register_script( 'gp-auto-extract-js', plugins_url('assets/js/gp-auto-extract.js', __FILE__) );
+			$translation_array = array(
+				'passwords' => array(
+					'none' => '',
+					'github' => __( 'or Personal Access Token' ),
+					'wordpress' => '',
+					'custom' => '',
+				),
+				'settings' => array(
+					'none' => '',
+					'github' => __( 'username/repository' ),
+					'wordpress' => __( 'plugin-or-theme-slug' ),
+					'custom' => __( 'url for a valid archive with source files' ),
+				),
+			);
+			wp_localize_script( 'gp-auto-extract-js', 'gpae', $translation_array );
+			wp_enqueue_script( 'gp-auto-extract-js' );
 	}
 
 	// This function is here as placeholder to support adding the auto extract option to the router.
@@ -154,40 +154,40 @@ class GP_Auto_Extract extends GP_Route_Main {
 		add_options_page( __('GP Auto Extract'), __('GP Auto Extract'), 'manage_options', basename( __FILE__ ), array( $this, 'admin_page' ) );
 	}
 
-    public function authenticate_download( $r, $url) {
-        if ( array_key_exists( $url, $this->url_credentials ) ) {
-            if ( ! is_array( $r['headers'] ) ) {
-                $r['headers'] = array();
-            };
-            $r['headers']['Authorization'] = 'Basic ' . base64_encode( $this->url_credentials[ $url ] );
-            $r['redirection'] = 1;
-        }
-        return $r;
-    }
+	public function authenticate_download( $r, $url) {
+		if ( array_key_exists( $url, $this->url_credentials ) ) {
+			if ( ! is_array( $r['headers'] ) ) {
+				$r['headers'] = array();
+			};
+			$r['headers']['Authorization'] = 'Basic ' . base64_encode( $this->url_credentials[ $url ] );
+			$r['redirection'] = 1;
+		}
+		return $r;
+	}
 
 	private function extract_project( $project, $project_settings, $format_message = true ) {
 		$url_name = sprintf(
-            $this->source_type_templates[ $project_settings[ $project->id ]['type'] ],
-            $project_settings[ $project->id ]['setting'],
-            $project_settings[ $project->id ]['branch'] ?: 'master'
-        );
+			$this->source_type_templates[ $project_settings[ $project->id ]['type'] ],
+			$project_settings[ $project->id ]['setting'],
+			$project_settings[ $project->id ]['branch'] ?: 'master'
+		);
 
-        $current_project = $project_settings[ $project->id ];
+		$current_project = $project_settings[ $project->id ];
 
-        $use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
-        $http_auth_username  = array_key_exists( 'http_auth_usernamehttp_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
-        $http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
+		$use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
+		$http_auth_username  = array_key_exists( 'http_auth_usernamehttp_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
+		$http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
 
-        if ( 'on' === $use_http_basic_auth ) {
-            $this->url_credentials[ $url_name ] = $http_auth_username . ':' . $http_auth_password;
-            add_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
-        }
+		if ( 'on' === $use_http_basic_auth ) {
+			$this->url_credentials[ $url_name ] = $http_auth_username . ':' . $http_auth_password;
+			add_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
+		}
 
 		$source_file = download_url( $url_name );
 
-        if ( $use_http_basic_auth ) {
-            remove_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
-        }
+		if ( $use_http_basic_auth ) {
+			remove_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
+		}
 
 		if( ! is_wp_error( $source_file ) ) {
 
@@ -229,29 +229,29 @@ class GP_Auto_Extract extends GP_Route_Main {
 			$makepot->meta['generic']['package-version'] = 'trunk';
 
 
-            $skip_makepot  = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
-            $import_format = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
-            $import_file   = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
+			$skip_makepot  = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
+			$import_format = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
+			$import_file   = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
 
-            if ( 'on' === $skip_makepot ) {
+			if ( 'on' === $skip_makepot ) {
 
-                $format = gp_array_get( GP::$formats, $import_format, null );
+				$format = gp_array_get( GP::$formats, $import_format, null );
 
-                $pot_file = $format->read_originals_from_file( $src_dir . ( $import_file[0] == '/' ? '' : '/' ) . $import_file );
+				$pot_file = $format->read_originals_from_file( $src_dir . ( $import_file[0] == '/' ? '' : '/' ) . $import_file );
 
-            } else {
+			} else {
 
-                $makepot = new MakePOT;
+				$makepot = new MakePOT;
 
-                $makepot->generic( $src_dir, $temp_pot );
+				$makepot->generic( $src_dir, $temp_pot );
 
-                $format = gp_array_get( GP::$formats, gp_post( 'format', 'po' ), null );
+				$format = gp_array_get( GP::$formats, gp_post( 'format', 'po' ), null );
 
-                $pot_file = $temp_pot;
+				$pot_file = $temp_pot;
 
-            }
+			}
 
-            $translations = $format->read_originals_from_file( $pot_file );
+			$translations = $format->read_originals_from_file( $pot_file );
 
 			$this->delTree( $temp_dir );
 			unlink( $temp_pot );
@@ -298,17 +298,17 @@ class GP_Auto_Extract extends GP_Route_Main {
 		// If the current user can't manage options, display a message and return immediately.
 		if( ! current_user_can( 'manage_options' ) ) { _e('You do not have permissions to this page!'); return; }
 
-        $empty_project = array(
-            'type' => 'none',
-            'setting' => '',
-            'branch' => '',
-            'use_http_basic_auth' => false,
-            'http_auth_username' => '',
-            'http_auth_password' => '',
-            'skip_makepot' => false,
-            'import_format' => '',
-            'import_file' => '',
-        );
+		$empty_project = array(
+			'type' => 'none',
+			'setting' => '',
+			'branch' => '',
+			'use_http_basic_auth' => false,
+			'http_auth_username' => '',
+			'http_auth_password' => '',
+			'skip_makepot' => false,
+			'import_format' => '',
+			'import_file' => '',
+		);
 
 
 		$projects = GP::$project->all();
@@ -321,13 +321,13 @@ class GP_Auto_Extract extends GP_Route_Main {
 			if( array_key_exists( 'save_' . $project->id, $_POST ) ) {
 				$project_settings[ $project->id ]['type']                = filter_input( INPUT_POST, 'source_type_' . $project->id );
 				$project_settings[ $project->id ]['setting']             = filter_input( INPUT_POST, 'setting_' . $project->id );
-                $project_settings[ $project->id ]['branch']              = filter_input( INPUT_POST, 'branch_' . $project->id );
-                $project_settings[ $project->id ]['use_http_basic_auth'] = filter_input( INPUT_POST, 'use_http_basic_auth_' . $project->id );
-                $project_settings[ $project->id ]['http_auth_username']  = filter_input( INPUT_POST, 'http_auth_username_' . $project->id );
-                $project_settings[ $project->id ]['http_auth_password']  = filter_input( INPUT_POST, 'http_auth_password_' . $project->id );
-                $project_settings[ $project->id ]['skip_makepot']        = filter_input( INPUT_POST, 'skip_makepot_' . $project->id );
-                $project_settings[ $project->id ]['import_format']       = filter_input( INPUT_POST, 'import_format_' . $project->id );
-                $project_settings[ $project->id ]['import_file']         = filter_input( INPUT_POST, 'import_file_' . $project->id );
+				$project_settings[ $project->id ]['branch']              = filter_input( INPUT_POST, 'branch_' . $project->id );
+				$project_settings[ $project->id ]['use_http_basic_auth'] = filter_input( INPUT_POST, 'use_http_basic_auth_' . $project->id );
+				$project_settings[ $project->id ]['http_auth_username']  = filter_input( INPUT_POST, 'http_auth_username_' . $project->id );
+				$project_settings[ $project->id ]['http_auth_password']  = filter_input( INPUT_POST, 'http_auth_password_' . $project->id );
+				$project_settings[ $project->id ]['skip_makepot']        = filter_input( INPUT_POST, 'skip_makepot_' . $project->id );
+				$project_settings[ $project->id ]['import_format']       = filter_input( INPUT_POST, 'import_format_' . $project->id );
+				$project_settings[ $project->id ]['import_file']         = filter_input( INPUT_POST, 'import_file_' . $project->id );
 
 				update_option( 'gp_auto_extract', $project_settings );
 			}
@@ -362,8 +362,8 @@ class GP_Auto_Extract extends GP_Route_Main {
 				<th><?php _e( 'Project' ); ?></th>
 				<th><?php _e( 'Source Type' ); ?></th>
 				<th><?php _e( 'Setting' ); ?></th>
-                <th><?php _e( 'Branch' ); ?></th>
-                <th><?php _e( 'Authorization' ); ?></th>
+				<th><?php _e( 'Branch' ); ?></th>
+				<th><?php _e( 'Authorization' ); ?></th>
 			</tr>
 			</thead>
 
@@ -375,154 +375,154 @@ class GP_Auto_Extract extends GP_Route_Main {
 		$setting = '';
 
 		if( array_key_exists( $project->id, $project_settings ) ) {
-            $current_project = $project_settings[ $project->id ];
+			$current_project = $project_settings[ $project->id ];
 
 			$source_type         = array_key_exists( 'type', $current_project ) ? $current_project['type'] : 'none';
 			$setting             = array_key_exists( 'setting', $current_project ) ? $current_project['setting'] : '';
-            $branch              = array_key_exists( 'branch', $current_project ) ? $current_project['branch'] : '';
-            $use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
-            $http_auth_username  = array_key_exists( 'http_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
-            $http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
-            $skip_makepot        = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
-            $import_format       = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
-            $import_file         = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
+			$branch              = array_key_exists( 'branch', $current_project ) ? $current_project['branch'] : '';
+			$use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
+			$http_auth_username  = array_key_exists( 'http_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
+			$http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
+			$skip_makepot        = array_key_exists( 'skip_makepot', $current_project ) ? $current_project['skip_makepot'] : '';
+			$import_format       = array_key_exists( 'import_format', $current_project ) ? $current_project['import_format'] : '';
+			$import_file         = array_key_exists( 'import_file', $current_project ) ? $current_project['import_file'] : '';
 		}
 
 		$row_actions = '';
-        $row_actions .= sprintf(
-            '<span class="edit"><a href="#" class="editinline" data-project-id="%s" aria-label="%s">%s</a></span>',
-            $project->id,
-            /* translators: %s: project name */
-            esc_attr( sprintf( __( 'Edit project &#8220;%s&#8221;' ), $project->name ) ),
-            __( 'Edit' )
-        );
+		$row_actions .= sprintf(
+			'<span class="edit"><a href="#" class="editinline" data-project-id="%s" aria-label="%s">%s</a></span>',
+			$project->id,
+			/* translators: %s: project name */
+			esc_attr( sprintf( __( 'Edit project &#8220;%s&#8221;' ), $project->name ) ),
+			__( 'Edit' )
+		);
 
-        if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
-            $row_actions .= sprintf(
-                ' | <span class="trash"><a href="#" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
-                $project->id,
-                /* translators: %s: project name */
-                esc_attr( sprintf( __( 'Reset &#8220;%s&#8221;' ), $project->name ) ),
-                __( 'Reset' )
-            );
+		if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
+			$row_actions .= sprintf(
+				' | <span class="trash"><a href="#" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
+				$project->id,
+				/* translators: %s: project name */
+				esc_attr( sprintf( __( 'Reset &#8220;%s&#8221;' ), $project->name ) ),
+				__( 'Reset' )
+			);
 
-            $row_actions .= sprintf(
-                ' | <span class="extract"><a href="#" class="extract-project" id="extract_%s" aria-label="%s">%s</a></span>',
-                $project->id,
-                /* translators: %s: project name */
-                esc_attr( sprintf( __( 'Extract &#8220;%s&#8221;' ), $project->name ) ),
-                __( 'Extract' )
-            );
-        }
+			$row_actions .= sprintf(
+				' | <span class="extract"><a href="#" class="extract-project" id="extract_%s" aria-label="%s">%s</a></span>',
+				$project->id,
+				/* translators: %s: project name */
+				esc_attr( sprintf( __( 'Extract &#8220;%s&#8221;' ), $project->name ) ),
+				__( 'Extract' )
+			);
+		}
 
-        if ( 'github' === $source_type ) {
-            $branch_label = $branch ?: 'master';
-            $use_http_basic_auth_label = $use_http_basic_auth ? __( 'Enabled' ) : __( 'Disabled' );
-        } elseif ( 'wordpress' === $source_type ) {
-            $branch_label = __( 'N/A' );
-            $use_http_basic_auth_label = __( 'N/A' );
-        } elseif ( 'custom' === $source_type ) {
-            $branch_label = __( 'N/A' );
-            $use_http_basic_auth_label = $use_http_basic_auth ? __( 'Enabled' ) : __( 'Disabled' );
-        } else {
-            $branch_label = '';
-            $use_http_basic_auth_label = '';
-        }
+		if ( 'github' === $source_type ) {
+			$branch_label = $branch ?: 'master';
+			$use_http_basic_auth_label = $use_http_basic_auth ? __( 'Enabled' ) : __( 'Disabled' );
+		} elseif ( 'wordpress' === $source_type ) {
+			$branch_label = __( 'N/A' );
+			$use_http_basic_auth_label = __( 'N/A' );
+		} elseif ( 'custom' === $source_type ) {
+			$branch_label = __( 'N/A' );
+			$use_http_basic_auth_label = $use_http_basic_auth ? __( 'Enabled' ) : __( 'Disabled' );
+		} else {
+			$branch_label = '';
+			$use_http_basic_auth_label = '';
+		}
 
-        ?>
-                <tr id="project-<?php echo esc_attr( $project->id ); ?>">
-                    <td class="title column-title has-row-actions column-primary">
-                        <strong><?php echo esc_html( $project->name ); ?></strong>
-                        <div class="row-actions"><?php echo $row_actions; ?></div>
-                    </td>
-                    <td><?php echo esc_html( $this->source_types[ $source_type ] ); ?></td>
-                    <td><?php echo esc_html( $setting ); ?></td>
-                    <td><?php echo esc_html( $branch_label ); ?></td>
-                    <td><?php echo esc_html( $use_http_basic_auth_label ); ?></td>
-                </tr>
-                <tr class="hidden"></tr>
-                <tr id="edit-project-<?php echo esc_attr( $project->id ); ?>" class="source-type-<?php echo esc_attr( $source_type ); ?> hidden inline-edit-row inline-edit-row-page inline-edit-page quick-edit-row quick-edit-row-page inline-edit-page inline-editor">
-                    <td colspan="5" class="colspanchange">
-                        <fieldset class="inline-edit-col-left">
-                            <legend class="inline-edit-legend"><?php echo esc_html__( 'Edit' ); ?></legend>
-                            <div class="inline-edit-col">
-                                <label>
-                                    <span class="title"><?php echo esc_html__( 'Project' ); ?></span>
-                                    <span class="input-text-wrap"><strong><?php echo esc_html( $project->name ); ?></strong></span>
-                                </label>
-                                <label>
-                                    <span class="title"><?php echo esc_html__( 'Source Type' ); ?></span>
-                                    <select class="source_type" name="source_type_<?php echo esc_attr( $project->id ); ?>" id="source_type_<?php echo esc_attr( $project->id ); ?>">
-                                    <?php foreach ( $this->source_types as $id => $type ) { ?>
-                                        <option value="<?php echo esc_attr( $id ); ?>" <?php echo selected( $source_type, $id ); ?>><?echo esc_html( $type ); ?></option>;
-                                    <?php } ?>
-                                    </select>
-                                </label>
-                                <label class="hide-if-none">
-                                    <span class="title"><?php echo esc_html__( 'Setting' ); ?></span>
-                                    <span class="input-text-wrap"><input type="text" class="gpae-setting" name="setting_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $setting ); ?>"></span>
-                                </label>
-                                <div class="inline-edit-group wp-clearfix show-if-github">
-                                    <label class="alignleft">
-                                        <span class="title"><?php echo esc_html__( 'Branch/Tag' ); ?></span>
-                                        <span class="input-text-wrap"><input type="text" name="branch_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $branch ); ?>" placeholder="master"></span>
-                                    </label>
-                                </div>
-                                <div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress">
-                                    <label class="alignleft">
-                                        <input type="checkbox" name="use_http_basic_auth_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $use_http_basic_auth, 'on' ); ?> class="group-toggle" data-group="httpauth-<?php echo esc_attr( $project->id ); ?>">
-                                        <span class="checkbox-title"><?php echo esc_html__( 'Use HTTP Basic Authentication' ); ?></span>
-                                    </label>
-                                </div>
-                                <div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress hidden group-httpauth-<?php echo esc_attr( $project->id ); ?>">
-                                    <label class="alignleft">
-                                        <span class="title"><?php echo esc_html__( 'Username' ); ?></span>
-                                        <span class="input-text-wrap"><input type="text" name="http_auth_username_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $http_auth_username ); ?>"></span>
-                                    </label>
-                                    <label class="alignleft">
-                                        <span class="title"><?php echo esc_html__( 'Password' ); ?></span>
-                                        <span class="input-text-wrap"><input type="text" class="gpae-password" name="http_auth_password_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $http_auth_password ); ?>"></span>
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                        <fieldset class="inline-edit-col-right">
-                            <div class="inline-edit-col">
-                                <div class="inline-edit-group wp-clearfix hide-if-none">
-                                    <label class="alignleft">
-                                        <input type="checkbox" name="skip_makepot_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $skip_makepot, 'on' ); ?> class="group-toggle" data-group="makepot-<?php echo esc_attr( $project->id ); ?>">
-                                        <span class="checkbox-title"><?php echo esc_html__( 'Import from existing file' ); ?></span>
-                                    </label>
-                                </div>
-                                <div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
-                                    <label class="alignleft">
-                                        <span class="title"><?php echo esc_html__( 'Format' ); ?></span>
-                                        <?php
-                                        $format_options = array();
-                                        foreach ( GP::$formats as $slug => $format ) {
-                                            $format_options[ $slug ] = $format->name;
-                                        }
-                                        echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'po' );
-                                        ?>
-                                    </label>
-                                </div>
-                                <div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
-                                    <label>
-                                        <span class="title"><?php echo esc_html__( 'File' ); ?></span>
-                                        <span class="input-text-wrap"><input type="text" name="import_file_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $import_file ); ?>" placeholder="<?php echo esc_attr__( 'path of file to import relative to repository or archive root' ); ?>"></span>
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                        <p class="submit inline-edit-save">
-                            <button type="button" class="button cancel alignleft" data-project-id="<? echo esc_attr( $project->id ); ?>"><?php echo esc_html( __( 'Cancel' ) ); ?></button>
-                            <input type="submit" name="save_<?php echo esc_attr( $project->id ); ?>" class="button button-primary save alignright" value="<?php echo esc_attr( __( 'Save' ) ); ?>"/>
-                            <br class="clear">
-                        </p>
-                    </td>
-                </tr>
-        <?php
-    }
+		?>
+				<tr id="project-<?php echo esc_attr( $project->id ); ?>">
+					<td class="title column-title has-row-actions column-primary">
+						<strong><?php echo esc_html( $project->name ); ?></strong>
+						<div class="row-actions"><?php echo $row_actions; ?></div>
+					</td>
+					<td><?php echo esc_html( $this->source_types[ $source_type ] ); ?></td>
+					<td><?php echo esc_html( $setting ); ?></td>
+					<td><?php echo esc_html( $branch_label ); ?></td>
+					<td><?php echo esc_html( $use_http_basic_auth_label ); ?></td>
+				</tr>
+				<tr class="hidden"></tr>
+				<tr id="edit-project-<?php echo esc_attr( $project->id ); ?>" class="source-type-<?php echo esc_attr( $source_type ); ?> hidden inline-edit-row inline-edit-row-page inline-edit-page quick-edit-row quick-edit-row-page inline-edit-page inline-editor">
+					<td colspan="5" class="colspanchange">
+						<fieldset class="inline-edit-col-left">
+							<legend class="inline-edit-legend"><?php echo esc_html__( 'Edit' ); ?></legend>
+							<div class="inline-edit-col">
+								<label>
+									<span class="title"><?php echo esc_html__( 'Project' ); ?></span>
+									<span class="input-text-wrap"><strong><?php echo esc_html( $project->name ); ?></strong></span>
+								</label>
+								<label>
+									<span class="title"><?php echo esc_html__( 'Source Type' ); ?></span>
+									<select class="source_type" name="source_type_<?php echo esc_attr( $project->id ); ?>" id="source_type_<?php echo esc_attr( $project->id ); ?>">
+									<?php foreach ( $this->source_types as $id => $type ) { ?>
+										<option value="<?php echo esc_attr( $id ); ?>" <?php echo selected( $source_type, $id ); ?>><?echo esc_html( $type ); ?></option>;
+									<?php } ?>
+									</select>
+								</label>
+								<label class="hide-if-none">
+									<span class="title"><?php echo esc_html__( 'Setting' ); ?></span>
+									<span class="input-text-wrap"><input type="text" class="gpae-setting" name="setting_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $setting ); ?>"></span>
+								</label>
+								<div class="inline-edit-group wp-clearfix show-if-github">
+									<label class="alignleft">
+										<span class="title"><?php echo esc_html__( 'Branch/Tag' ); ?></span>
+										<span class="input-text-wrap"><input type="text" name="branch_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $branch ); ?>" placeholder="master"></span>
+									</label>
+								</div>
+								<div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress">
+									<label class="alignleft">
+										<input type="checkbox" name="use_http_basic_auth_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $use_http_basic_auth, 'on' ); ?> class="group-toggle" data-group="httpauth-<?php echo esc_attr( $project->id ); ?>">
+										<span class="checkbox-title"><?php echo esc_html__( 'Use HTTP Basic Authentication' ); ?></span>
+									</label>
+								</div>
+								<div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress hidden group-httpauth-<?php echo esc_attr( $project->id ); ?>">
+									<label class="alignleft">
+										<span class="title"><?php echo esc_html__( 'Username' ); ?></span>
+										<span class="input-text-wrap"><input type="text" name="http_auth_username_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $http_auth_username ); ?>"></span>
+									</label>
+									<label class="alignleft">
+										<span class="title"><?php echo esc_html__( 'Password' ); ?></span>
+										<span class="input-text-wrap"><input type="text" class="gpae-password" name="http_auth_password_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $http_auth_password ); ?>"></span>
+									</label>
+								</div>
+							</div>
+						</fieldset>
+						<fieldset class="inline-edit-col-right">
+							<div class="inline-edit-col">
+								<div class="inline-edit-group wp-clearfix hide-if-none">
+									<label class="alignleft">
+										<input type="checkbox" name="skip_makepot_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $skip_makepot, 'on' ); ?> class="group-toggle" data-group="makepot-<?php echo esc_attr( $project->id ); ?>">
+										<span class="checkbox-title"><?php echo esc_html__( 'Import from existing file' ); ?></span>
+									</label>
+								</div>
+								<div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
+									<label class="alignleft">
+										<span class="title"><?php echo esc_html__( 'Format' ); ?></span>
+										<?php
+										$format_options = array();
+										foreach ( GP::$formats as $slug => $format ) {
+											$format_options[ $slug ] = $format->name;
+										}
+										echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'po' );
+										?>
+									</label>
+								</div>
+								<div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
+									<label>
+										<span class="title"><?php echo esc_html__( 'File' ); ?></span>
+										<span class="input-text-wrap"><input type="text" name="import_file_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $import_file ); ?>" placeholder="<?php echo esc_attr__( 'path of file to import relative to repository or archive root' ); ?>"></span>
+									</label>
+								</div>
+							</div>
+						</fieldset>
+						<p class="submit inline-edit-save">
+							<button type="button" class="button cancel alignleft" data-project-id="<? echo esc_attr( $project->id ); ?>"><?php echo esc_html( __( 'Cancel' ) ); ?></button>
+							<input type="submit" name="save_<?php echo esc_attr( $project->id ); ?>" class="button button-primary save alignright" value="<?php echo esc_attr( __( 'Save' ) ); ?>"/>
+							<br class="clear">
+						</p>
+					</td>
+				</tr>
+		<?php
+	}
 ?>
 
 			</tbody>

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -6,7 +6,7 @@ Description: Automatically extract source strings from a remote repo.
 Version: 0.7
 Author: Greg Ross
 Author URI: http://toolstack.com
-Tags: glotpress, glotpress plugin, translate 
+Tags: glotpress, glotpress plugin, translate
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
@@ -21,26 +21,28 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * stub functions to mimic the GP_Route class that the GP Router needs to function correctly.
  */
 class GP_Auto_Extract extends GP_Route_Main {
-	public $id = 'gp-auot-extract';
+	public $id = 'gp-auto-extract';
 
 	private	$source_types;
 	private $source_type_templates;
+    private $url_credentials = array();
 
 	public function __construct() {
 		$this->source_types = array( 'none' => __( 'none' ), 'github' => __( 'GitHub' ), 'wordpress' => __( 'WordPress.org' ), 'custom' => __( 'Custom' ) );
-		$this->source_type_templates = array( 
+		$this->source_type_templates = array(
 											'none' 		=> '',
-											'github' 	=> 'https://github.com/%s/archive/master.zip',
+											'github' 	=> 'https://github.com/%s/archive/%s.zip',
 											'wordpress' => 'https://downloads.wordpress.org/plugin/%s.zip',
 											'custom' 	=> '%s',
 										);
 
 		// Add the admin page to the WordPress settings menu.
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 10, 1 );
-		
+        add_action( 'admin_enqueue_scripts', array( $this, 'load_custom_wp_admin_style' ) );
+
 		// If the user has write permissions to the projects, add the auto extract option to the projects menu.
 		if( GP::$permission->user_can( wp_get_current_user(), 'write', 'project' ) ) {
-			add_action( 'gp_project_actions', array( $this, 'gp_project_actions'), 10, 2 );
+			add_action( 'gp_project_actions', array( $this, 'gp_project_actions' ), 10, 2 );
 		}
 
 		// We can't use the filter in the defaults route code because plugins don't load until after
@@ -48,18 +50,49 @@ class GP_Auto_Extract extends GP_Route_Main {
 		GP::$router->add( "/auto-extract/(.+?)", array( $this, 'auto_extract' ), 'get' );
 		GP::$router->add( "/auto-extract/(.+?)", array( $this, 'auto_extract' ), 'post' );
 	}
-	
+
+	public function load_custom_wp_admin_style( $hook ) {
+            // Load only on ?page=gp-auto-extract.php
+            if ( $hook != 'settings_page_gp-auto-extract' ) {
+                return;
+            }
+            wp_enqueue_style( 'gp-auto-extract-css', plugins_url('assets/css/gp-auto-extract.css', __FILE__) );
+
+            wp_register_script( 'gp-auto-extract-js', plugins_url('assets/js/gp-auto-extract.js', __FILE__) );
+            $translation_array = array(
+                'passwords' => array(
+                    'none' => '',
+                    'github' => __( 'or Personal Access Token' ),
+                    'wordpress' => '',
+                    'custom' => '',
+                ),
+                'settings' => array(
+                    'none' => '',
+                    'github' => __( 'username/repository' ),
+                    'wordpress' => __( 'plugin-or-theme-slug' ),
+                    'custom' => __( 'url for a valid archive with source files' ),
+                ),
+            );
+            wp_localize_script( 'gp-auto-extract-js', 'gpae', $translation_array );
+            wp_enqueue_script( 'gp-auto-extract-js' );
+	}
+
+	// This function is here as placeholder to support adding the auto extract option to the router.
+	// Without this placeholder there is a fatal error generated.
+	public function before_request() {
+	}
+
 	// This function handles the actual auto extract passed in by the router for the projects menu.
 	public function auto_extract( $project_path ) {
 		// First let's ensure we have decoded the project path for use later.
 		$project_path = urldecode( $project_path );
-		
+
 		// Get the URL to the project for use later.
 		$url = gp_url_project( $project_path );
 
 		// Create a project class to use to get the project object.
 		$project_class = new GP_Project;
-		
+
 		// Get the project object from the project path that was passed in.
 		$project_obj = $project_class->by_path( $project_path );
 
@@ -77,29 +110,34 @@ class GP_Auto_Extract extends GP_Route_Main {
 		}
 
 		gp_notice_set( $message );
-		
+
 		// Redirect back to the project home.
 		wp_redirect( $url );
+	}
+
+	// This function is here as placeholder to support adding the auto extract option to the router.
+	// Without this placeholder there is a fatal error generated.
+	public function after_request() {
 	}
 	
 	// This function adds the "Auto Extract" option to the projects menu.
 	public function gp_project_actions( $actions, $project ) {
 		$project_settings = (array)get_option( 'gp_auto_extract', array() );
-		
+
 		if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
 			$actions[] .= gp_link_get( gp_url( 'auto-extract/' . $project->slug), __('Auto Extract') );
 		}
-		
+
 		return $actions;
 	}
-	
+
 	private function delTree( $dir ) {
 		if( ! gp_startswith( $dir, sys_get_temp_dir() ) ) {
 			return false;
 		}
 
 		$files = array_diff( scandir( $dir ), array( '.', '..' ) );
-		
+
 		foreach ( $files as $file ) {
 			if( is_dir( "$dir/$file" ) ) {
 				$this->delTree("$dir/$file");
@@ -107,28 +145,56 @@ class GP_Auto_Extract extends GP_Route_Main {
 				unlink("$dir/$file");
 			}
 		}
-    
+
 		return rmdir( $dir );
-	} 
-	
+	}
+
 	// This function adds the admin settings page to WordPress.
 	public function admin_menu() {
 		add_options_page( __('GP Auto Extract'), __('GP Auto Extract'), 'manage_options', basename( __FILE__ ), array( $this, 'admin_page' ) );
 	}
 
+    public function authenticate_download( $r, $url) {
+        if ( array_key_exists( $url, $this->url_credentials ) ) {
+            if ( ! is_array( $r['headers'] ) ) {
+                $r['headers'] = array();
+            };
+            $r['headers']['Authorization'] = 'Basic ' . base64_encode( $this->url_credentials[ $url ] );
+            $r['redirection'] = 1;
+        }
+        return $r;
+    }
+
 	private function extract_project( $project, $project_settings, $format_message = true ) {
-		$url_name = sprintf( $this->source_type_templates[ $project_settings[ $project->id ][ 'type' ] ], $project_settings[ $project->id ][ 'setting' ] );
+		$url_name = sprintf(
+            $this->source_type_templates[ $project_settings[ $project->id ]['type'] ],
+            $project_settings[ $project->id ]['setting'],
+            $project_settings[ $project->id ]['branch'] ?: 'master'
+        );
+
+        $use_http_basic_auth = $project_settings[ $project->id ]['use_http_basic_auth'];
+        $http_auth_username  = $project_settings[ $project->id ]['http_auth_username'];
+        $http_auth_password  = $project_settings[ $project->id ]['http_auth_password'];
+
+        if ( 'on' === $use_http_basic_auth ) {
+            $this->url_credentials[ $url_name ] = $http_auth_username . ':' . $http_auth_password;
+            add_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
+        }
 
 		$source_file = download_url( $url_name );
 
+        if ( $use_http_basic_auth ) {
+            remove_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
+        }
+
 		if( ! is_wp_error( $source_file ) ) {
-			
+
 			include( dirname( __FILE__ ) . '/include/extract/makepot.php' );
 
 			// Get a temporary file, use gpa as the first four letters of it.
 			$temp_dir = tempnam( sys_get_temp_dir(), 'gpa');
 			$temp_pot = tempnam( sys_get_temp_dir(), 'gpa');
-			
+
 			// Now delete the file and recreate it as a directory.
 			unlink( $temp_dir );
 			mkdir( $temp_dir );
@@ -137,51 +203,67 @@ class GP_Auto_Extract extends GP_Route_Main {
 			if ( $zip->open( $source_file ) === TRUE ) {
 				$zip->extractTo( $temp_dir );
 				$zip->close();
-				
+
 				unlink( $source_file );
 			} else {
 				unlink( $source_file );
-				
+
 				return '<div class="notice updated"><p>' . sprintf( __('Failed to extract zip file: "%s".' ), $source_file ) . '</p></div>';
 			}
 
 			$src_dir = $temp_dir;
-			
+
 			// Check to see if there is only a single directory in the resulting zip extract root directory, if so, make it the root of the makepot call.
 			$src_files = scandir( $src_dir );
-			
+
 			// If there are exactly three files in the list ( '.', '..' and something else ) then check the third one and if it's a directory, make it he new $src_dir.
 			if( count( $src_files ) == 3 ) {
 				if( is_dir( $src_dir . '/' . $src_files[2] ) ) {
 					$src_dir .= '/' . $src_files[2];
 				}
 			}
-			
-			$makepot = new MakePOT;
-			
 			// Fudge the project name and version so the makepot call doesn't generate warnings about them.
 			$makepot->meta['generic']['package-name'] = $project->name;
 			$makepot->meta['generic']['package-version'] = 'trunk';
 			
-			$makepot->generic( $src_dir, $temp_pot );
-			
-			$format = gp_array_get( GP::$formats, gp_post( 'format', 'po' ), null );
 
-			$translations = $format->read_originals_from_file( $temp_pot );
+            $skip_makepot  = $project_settings[ $project->id ]['skip_makepot'];
+            $import_format = $project_settings[ $project->id ]['import_format'];
+            $import_file   = $project_settings[ $project->id ]['import_file'];
+
+            if ( 'on' === $skip_makepot ) {
+
+                $format = gp_array_get( GP::$formats, $import_format, null );
+
+                $pot_file = $format->read_originals_from_file( $src_dir . ( $import_file[0] == '/' ? '' : '/' ) . $import_file );
+
+            } else {
+
+                $makepot = new MakePOT;
+
+                $makepot->generic( $src_dir, $temp_pot );
+
+                $format = gp_array_get( GP::$formats, gp_post( 'format', 'po' ), null );
+
+                $pot_file = $temp_pot;
+
+            }
+
+            $translations = $format->read_originals_from_file( $pot_file );
 
 			$this->delTree( $temp_dir );
 			unlink( $temp_pot );
-			
+
 			if( FALSE === $translations ) {
 				return '<div class="notice updated"><p>' . __( 'Failed to read strings from source code.' ) . '</p></div>';
 			}
-			
+
 			list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted ) = GP::$original->import_for_project( $project, $translations );
 
 			if( true === $format_message ) {
 				$message = '<div class="notice updated"><p>';
 			}
-			
+
 			$message .= sprintf(
 				__( '%1$s new strings added, %2$s updated, %3$s fuzzied, and %4$s obsoleted in the "%5$s" project.' ),
 				$originals_added,
@@ -190,7 +272,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 				$originals_obsoleted,
 				$project->name
 			);
-			
+
 			if( true === $format_message ) {
 				$message .= '</p></div>';
 			}
@@ -208,30 +290,49 @@ class GP_Auto_Extract extends GP_Route_Main {
 
 		return $message;
 	}
-	
+
 	// This function displays the admin settings page in WordPress.
 	public function admin_page() {
 		// If the current user can't manage options, display a message and return immediately.
 		if( ! current_user_can( 'manage_options' ) ) { _e('You do not have permissions to this page!'); return; }
 
+        $empty_project = array(
+            'type' => 'none',
+            'setting' => '',
+            'branch' => '',
+            'use_http_basic_auth' => false,
+            'http_auth_username' => '',
+            'http_auth_password' => '',
+            'skip_makepot' => false,
+            'import_format' => '',
+            'import_file' => '',
+        );
+
+
 		$projects = GP::$project->all();
-	
+
 		$message = '';
-		
+
 		$project_settings = (array)get_option( 'gp_auto_extract', array() );
-		
+
 		foreach( $projects as $project ) {
 			if( array_key_exists( 'save_' . $project->id, $_POST ) ) {
-				$project_settings[ $project->id ][ 'type' ] = $_POST[ 'source_type_' . $project->id ];
-				$project_settings[ $project->id ][ 'setting' ] = $_POST[ 'setting_' . $project->id ];
-				
+				$project_settings[ $project->id ]['type']                = $_POST[ 'source_type_' . $project->id ];
+				$project_settings[ $project->id ]['setting']             = $_POST[ 'setting_' . $project->id ];
+                $project_settings[ $project->id ]['branch']              = $_POST[ 'branch_' . $project->id ];
+                $project_settings[ $project->id ]['use_http_basic_auth'] = $_POST[ 'use_http_basic_auth_' . $project->id ];
+                $project_settings[ $project->id ]['http_auth_username']  = $_POST[ 'http_auth_username_' . $project->id ];
+                $project_settings[ $project->id ]['http_auth_password']  = $_POST[ 'http_auth_password_' . $project->id ];
+                $project_settings[ $project->id ]['skip_makepot']        = $_POST[ 'skip_makepot_' . $project->id ];
+                $project_settings[ $project->id ]['import_format']       = $_POST[ 'import_format_' . $project->id ];
+                $project_settings[ $project->id ]['import_file']         = $_POST[ 'import_file_' . $project->id ];
+
 				update_option( 'gp_auto_extract', $project_settings );
 			}
-			
+
 			if( array_key_exists( 'delete_' . $project->id, $_POST ) ) {
-				$project_settings[ $project->id ][ 'type' ] = 'none';
-				$project_settings[ $project->id ][ 'setting' ] = '';
-				
+				$project_settings[ $project->id ] = $empty_project;
+
 				update_option( 'gp_auto_extract', $project_settings );
 			}
 
@@ -243,66 +344,189 @@ class GP_Auto_Extract extends GP_Route_Main {
 				}
 			}
 		}
-		
-	?>	
+	?>
 <div class="wrap">
 	<?php echo $message; ?>
 
-	<h2><?php _e('GP Auto Extract Settings');?></h2>
+	<h2><?php _e('GP Auto Extract Settings'); ?></h2>
 
 	<br />
-	
-	<form method="post" action="options-general.php?page=gp-auto-extract.php" >	
-	
-		<table class="widefat">
+
+	<form method="post" id="gp-auto-extract" action="options-general.php?page=gp-auto-extract.php" >
+
+		<table class="widefat striped">
 			<thead>
 			<tr>
-				<th><?php _e( 'Project' ); ?></td>
-				<th><?php _e( 'Source Type' ); ?></td>
-				<th><?php _e( 'Setting' ); ?></td>
-				<th><?php _e( 'Options' ); ?></td>
+				<th><?php _e( 'Project' ); ?></th>
+				<th><?php _e( 'Source Type' ); ?></th>
+				<th><?php _e( 'Setting' ); ?></th>
+                <th><?php _e( 'Branch' ); ?></th>
+                <th><?php _e( 'Authorization' ); ?></th>
 			</tr>
 			</thead>
 
-			<tbody>
+			<tbody id="the-list">
 
 <?php
 	foreach( $projects as $project ) {
 		$source_type = 'none';
 		$setting = '';
-		
+
 		if( array_key_exists( $project->id, $project_settings ) ) {
-			$source_type = $project_settings[ $project->id ][ 'type' ];
-			$setting = $project_settings[ $project->id ][ 'setting' ];
+			$source_type         = $project_settings[ $project->id ]['type'];
+			$setting             = $project_settings[ $project->id ]['setting'];
+            $branch              = $project_settings[ $project->id ]['branch'];
+            $use_http_basic_auth = $project_settings[ $project->id ]['use_http_basic_auth'] ?: false;
+            $http_auth_username  = $project_settings[ $project->id ]['http_auth_username'];
+            $http_auth_password  = $project_settings[ $project->id ]['http_auth_password'];
+            $skip_makepot        = $project_settings[ $project->id ]['skip_makepot'] ?: false;
+            $import_format       = $project_settings[ $project->id ]['import_format'];
+            $import_file         = $project_settings[ $project->id ]['import_file'];
 		}
-		
-		$buttons = '';
-		$buttons .= get_submit_button( __('Save'), 'primary', 'save_' . $project->id, false ) . '&nbsp;';
-		
-		if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
-			$buttons .= get_submit_button( __('Delete'), 'delete', 'delete_' . $project->id, false ) . '&nbsp;';
-			$buttons .= get_submit_button( __('Extract'), 'secondary', 'extract_' . $project->id, false ) . '&nbsp;';
-		}
-		
-		$source_type_selector = '<select name="source_type_' . $project->id . '" id="source_type_' . $project->id . '">';
-		
-		foreach( $this->source_types as $id => $type ) {
-			$id == $source_type ? $id_selected  = ' SELECTED' : $id_selected = '';
-			$source_type_selector .= '<option value="' . $id . '"' . $id_selected . '>' . $type . '</option>';
-		}
-		
-		$source_type_selector .= '</select>';
-		
-		echo '<tr><td>' . $project->name . '</td><td>' . $source_type_selector . '</td><td><input name="setting_' . $project->id . '" id="setting_' . $project->id . '" type="text" size="45" value="' . $setting . '"></input></td><td> ' . $buttons . '</td></tr>';
-	}
-?>	
-	
+
+		$row_actions = '';
+        $row_actions .= sprintf(
+            '<span class="edit"><a href="#" class="editinline" data-project-id="%s" aria-label="%s">%s</a></span>',
+            $project->id,
+            /* translators: %s: project name */
+            esc_attr( sprintf( __( 'Edit project &#8220;%s&#8221;' ), $project->name ) ),
+            __( 'Edit' )
+        );
+
+        if( is_array( $project_settings ) && array_key_exists( $project->id, $project_settings) && is_array( $project_settings[ $project->id ] ) && array_key_exists( 'type',  $project_settings[ $project->id ] ) && 'none' != $project_settings[ $project->id ][ 'type' ] ) {
+            $row_actions .= sprintf(
+                ' | <span class="trash"><a href="#" class="submitdelete reset-project" id="delete_%s" aria-label="%s">%s</a></span>',
+                $project->id,
+                /* translators: %s: project name */
+                esc_attr( sprintf( __( 'Reset &#8220;%s&#8221;' ), $project->name ) ),
+                __( 'Reset' )
+            );
+
+            $row_actions .= sprintf(
+                ' | <span class="extract"><a href="#" class="extract-project" id="extract_%s" aria-label="%s">%s</a></span>',
+                $project->id,
+                /* translators: %s: project name */
+                esc_attr( sprintf( __( 'Extract &#8220;%s&#8221;' ), $project->name ) ),
+                __( 'Extract' )
+            );
+        }
+
+        if ( 'github' === $source_type ) {
+            $branch_label = $branch ?: 'master';
+            $use_http_basic_auth_label = $use_http_basic_auth ? __( 'Enabled' ) : __( 'Disabled' );
+        } elseif ( 'wordpress' === $source_type ) {
+            $branch_label = __( 'N/A' );
+            $use_http_basic_auth_label = __( 'N/A' );
+        } elseif ( 'custom' === $source_type ) {
+            $branch_label = __( 'N/A' );
+            $use_http_basic_auth_label = $use_http_basic_auth ? __( 'Enabled' ) : __( 'Disabled' );
+        } else {
+            $branch_label = '';
+            $use_http_basic_auth_label = '';
+        }
+
+        ?>
+                <tr id="project-<?php echo esc_attr( $project->id ); ?>">
+                    <td class="title column-title has-row-actions column-primary">
+                        <strong><?php echo esc_html( $project->name ); ?></strong>
+                        <div class="row-actions"><?php echo $row_actions; ?></div>
+                    </td>
+                    <td><?php echo esc_html( $this->source_types[ $source_type ] ); ?></td>
+                    <td><?php echo esc_html( $setting ); ?></td>
+                    <td><?php echo esc_html( $branch_label ); ?></td>
+                    <td><?php echo esc_html( $use_http_basic_auth_label ); ?></td>
+                </tr>
+                <tr class="hidden"></tr>
+                <tr id="edit-project-<?php echo esc_attr( $project->id ); ?>" class="source-type-<?php echo esc_attr( $source_type ); ?> hidden inline-edit-row inline-edit-row-page inline-edit-page quick-edit-row quick-edit-row-page inline-edit-page inline-editor">
+                    <td colspan="5" class="colspanchange">
+                        <fieldset class="inline-edit-col-left">
+                            <legend class="inline-edit-legend"><?php echo esc_html__( 'Edit' ); ?></legend>
+                            <div class="inline-edit-col">
+                                <label>
+                                    <span class="title"><?php echo esc_html__( 'Project' ); ?></span>
+                                    <span class="input-text-wrap"><strong><?php echo esc_html( $project->name ); ?></strong></span>
+                                </label>
+                                <label>
+                                    <span class="title"><?php echo esc_html__( 'Source Type' ); ?></span>
+                                    <select class="source_type" name="source_type_<?php echo esc_attr( $project->id ); ?>" id="source_type_<?php echo esc_attr( $project->id ); ?>">
+                                    <?php foreach ( $this->source_types as $id => $type ) { ?>
+                                        <option value="<?php echo esc_attr( $id ); ?>" <?php echo selected( $source_type, $id ); ?>><?echo esc_html( $type ); ?></option>;
+                                    <?php } ?>
+                                    </select>
+                                </label>
+                                <label class="hide-if-none">
+                                    <span class="title"><?php echo esc_html__( 'Setting' ); ?></span>
+                                    <span class="input-text-wrap"><input type="text" class="gpae-setting" name="setting_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $setting ); ?>"></span>
+                                </label>
+                                <div class="inline-edit-group wp-clearfix show-if-github">
+                                    <label class="alignleft">
+                                        <span class="title"><?php echo esc_html__( 'Branch/Tag' ); ?></span>
+                                        <span class="input-text-wrap"><input type="text" name="branch_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $branch ); ?>" placeholder="master"></span>
+                                    </label>
+                                </div>
+                                <div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress">
+                                    <label class="alignleft">
+                                        <input type="checkbox" name="use_http_basic_auth_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $use_http_basic_auth, 'on' ); ?> class="group-toggle" data-group="httpauth-<?php echo esc_attr( $project->id ); ?>">
+                                        <span class="checkbox-title"><?php echo esc_html__( 'Use HTTP Basic Authentication' ); ?></span>
+                                    </label>
+                                </div>
+                                <div class="inline-edit-group wp-clearfix hide-if-none hide-if-wordpress hidden group-httpauth-<?php echo esc_attr( $project->id ); ?>">
+                                    <label class="alignleft">
+                                        <span class="title"><?php echo esc_html__( 'Username' ); ?></span>
+                                        <span class="input-text-wrap"><input type="text" name="http_auth_username_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $http_auth_username ); ?>"></span>
+                                    </label>
+                                    <label class="alignleft">
+                                        <span class="title"><?php echo esc_html__( 'Password' ); ?></span>
+                                        <span class="input-text-wrap"><input type="text" class="gpae-password" name="http_auth_password_<?php echo esc_attr( $project->id ); ?>" class="inline-edit-password-input" value="<?php echo esc_attr( $http_auth_password ); ?>"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
+                        <fieldset class="inline-edit-col-right">
+                            <div class="inline-edit-col">
+                                <div class="inline-edit-group wp-clearfix hide-if-none">
+                                    <label class="alignleft">
+                                        <input type="checkbox" name="skip_makepot_<?php echo esc_attr( $project->id ); ?>" <?php echo checked( $skip_makepot, 'on' ); ?> class="group-toggle" data-group="makepot-<?php echo esc_attr( $project->id ); ?>">
+                                        <span class="checkbox-title"><?php echo esc_html__( 'Import from existing file' ); ?></span>
+                                    </label>
+                                </div>
+                                <div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
+                                    <label class="alignleft">
+                                        <span class="title"><?php echo esc_html__( 'Format' ); ?></span>
+                                        <?php
+                                        $format_options = array();
+                                        foreach ( GP::$formats as $slug => $format ) {
+                                            $format_options[ $slug ] = $format->name;
+                                        }
+                                        echo gp_select( 'import_format_' . $project->id, $format_options, $import_format ?: 'po' );
+                                        ?>
+                                    </label>
+                                </div>
+                                <div class="inline-edit-group wp-clearfix hide-if-none hidden group-makepot-<?php echo esc_attr( $project->id ); ?>">
+                                    <label>
+                                        <span class="title"><?php echo esc_html__( 'File' ); ?></span>
+                                        <span class="input-text-wrap"><input type="text" name="import_file_<?php echo esc_attr( $project->id ); ?>" value="<?php echo esc_attr( $import_file ); ?>" placeholder="<?php echo esc_attr__( 'path of file to import relative to repository or archive root' ); ?>"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
+                        <p class="submit inline-edit-save">
+                            <button type="button" class="button cancel alignleft" data-project-id="<? echo esc_attr( $project->id ); ?>"><?php echo esc_html( __( 'Cancel' ) ); ?></button>
+                            <input type="submit" name="save_<?php echo esc_attr( $project->id ); ?>" class="button button-primary save alignright" value="<?php echo esc_attr( __( 'Save' ) ); ?>"/>
+                            <br class="clear">
+                        </p>
+                    </td>
+                </tr>
+        <?php
+    }
+?>
+
 			</tbody>
-		</table>		
+		</table>
 	</form>
-	
+
 </div>
-<?php		
+<?php
 	}
 }
 
@@ -312,6 +536,6 @@ add_action( 'gp_init', 'gp_auto_extract_init' );
 // This function creates the plugin.
 function gp_auto_extract_init() {
 	GLOBAL $gp_auto_extract;
-	
+
 	$gp_auto_extract = new GP_Auto_Extract;
 }

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -271,14 +271,17 @@ class GP_Auto_Extract extends GP_Route_Main {
 		$current_project = $project_settings[ $project->id ];
 
 		$use_http_basic_auth = array_key_exists( 'use_http_basic_auth', $current_project ) ? $current_project['use_http_basic_auth'] : '';
-		$http_auth_username  = array_key_exists( 'http_auth_usernamehttp_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
-		$http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
-		if ( ! empty( $http_auth_password ) ) {
-			$http_auth_password = $this->decrypt_data( $http_auth_password );
-		}
 
 		if ( 'on' === $use_http_basic_auth ) {
+			$http_auth_username  = array_key_exists( 'http_auth_username', $current_project ) ? $current_project['http_auth_username'] : '';
+			$http_auth_password  = array_key_exists( 'http_auth_password', $current_project ) ? $current_project['http_auth_password'] : '';
+
+			if ( ! empty( $http_auth_password ) ) {
+				$http_auth_password = $this->decrypt_data( $http_auth_password );
+			}
+
 			$this->url_credentials[ $url_name ] = $http_auth_username . ':' . $http_auth_password;
+
 			add_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
 		}
 

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -96,7 +96,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 		// Get the project object from the project path that was passed in.
 		$project_obj = $project_class->by_path( $project_path );
 
-		if( GP::$permission->user_can( wp_get_current_user(), 'write', 'project', $project->id ) ) {
+		if( GP::$permission->user_can( wp_get_current_user(), 'write', 'project', $project_obj->id ) ) {
 			// Get the project settings.
 			$project_settings = (array)get_option( 'gp_auto_extract', array() );
 
@@ -189,6 +189,8 @@ class GP_Auto_Extract extends GP_Route_Main {
 			remove_filter( 'http_request_args', array( $this, 'authenticate_download' ), 10, 2 );
 		}
 
+		$message = '';
+
 		if( ! is_wp_error( $source_file ) ) {
 
 			include( dirname( __FILE__ ) . '/include/extract/makepot.php' );
@@ -263,7 +265,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted ) = GP::$original->import_for_project( $project, $translations );
 
 			if( true === $format_message ) {
-				$message = '<div class="notice updated"><p>';
+				$message .= '<div class="notice updated"><p>';
 			}
 
 			$message .= sprintf(
@@ -280,7 +282,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 			}
 		} else {
 			if( true === $format_message ) {
-				$message = '<div class="notice updated"><p>';
+				$message .= '<div class="notice updated"><p>';
 			}
 
 			$message .= sprintf( __('Failed to download "%s".' ), $url_name ) . '</p></div>';

--- a/gp-auto-extract.php
+++ b/gp-auto-extract.php
@@ -344,7 +344,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 						$message .= '<div class="notice error"><p>';
 					}
 
-					$message .= sprintf( __( 'Failed to detect format for "%s".' ), $import_file ) . '</p></div>';
+					$message .= sprintf( __( 'Failed to detect format for "%s".' ), $import_file );
 
 					if ( true === $format_message ) {
 						$message .= '</p></div>';
@@ -403,7 +403,7 @@ class GP_Auto_Extract extends GP_Route_Main {
 				$message .= '<div class="notice error"><p>';
 			}
 
-			$message .= sprintf( __( 'Failed to download "%s".' ), $url_name ) . '</p></div>';
+			$message .= sprintf( __( 'Failed to download "%s".' ), $url_name );
 
 			if ( true === $format_message ) {
 				$message .= '</p></div>';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="Xpress">
+	<description>Xpress Coding Standards</description>
+
+	<!-- Show colors in console -->
+	<arg value="-colors"/>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Extra">
+		<exclude name="WordPress.XSS.EscapeOutput"/>
+	</rule>
+	<rule ref="WordPress-Docs"/>
+</ruleset>


### PR DESCRIPTION
- Added support for HTTP Basic Authentication (can be used with Personal Access Tokens to access private GitHub repositories)
- Added option to skip POT generation and import an existing file from repository/archive
- Added option to override GitHub branch or tag
- Modified settings page for better user experience (similar to standard WordPress inline edit)
- Improved settings page self-explanation using placeholders in fields
- Fixed main plugin file to pass validations on: `WordPress-Core`, `WordPress-Extra` and `WordPress-Docs`.